### PR TITLE
Added missing classes from the ones removed in core

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Finder\Finder;
 use Symfony\Bundle\FrameworkBundle\Util\Filesystem;
-use Symfony\Bundle\DoctrineAbstractBundle\Common\DataFixtures\Loader as DataFixturesLoader;
+use Symfony\Bundle\DoctrineFixturesBundle\Common\DataFixtures\Loader as DataFixturesLoader;
 use Symfony\Bundle\DoctrineBundle\Command\DoctrineCommand;
 use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;

--- a/Command/LoadDataFixturesDoctrineODMCommand.php
+++ b/Command/LoadDataFixturesDoctrineODMCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Finder\Finder;
 use Symfony\Bundle\FrameworkBundle\Util\Filesystem;
-use Symfony\Bundle\DoctrineAbstractBundle\Common\DataFixtures\Loader as DataFixturesLoader;
+use Symfony\Bundle\DoctrineFixturesBundle\Common\DataFixtures\Loader as DataFixturesLoader;
 use Symfony\Bundle\DoctrineMongoDBBundle\Command\DoctrineODMCommand;
 use Doctrine\Common\DataFixtures\Executor\MongoDBExecutor;
 use Doctrine\Common\DataFixtures\Purger\MongoDBPurger;

--- a/Common/DataFixtures/Loader.php
+++ b/Common/DataFixtures/Loader.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Symfony\Bundle\DoctrineAbstractBundle\Common\DataFixtures;
+namespace Symfony\Bundle\DoctrineFixturesBundle\Common\DataFixtures;
 
 use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Common\DataFixtures\Loader as BaseLoader;

--- a/Tests/Common/ContainerAwareFixture.php
+++ b/Tests/Common/ContainerAwareFixture.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Symfony\Bundle\DoctrineAbstractBundle\Tests\Common;
+namespace Symfony\Bundle\DoctrineFixturesBundle\Tests\Common;
 
 use Doctrine\Common\DataFixtures\FixtureInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/Tests/Common/DataFixtures/LoaderTest.php
+++ b/Tests/Common/DataFixtures/LoaderTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Symfony\Bundle\DoctrineAbstractBundle\Tests\Common\DataFixtures;
+namespace Symfony\Bundle\DoctrineFixturesBundle\Tests\Common\DataFixtures;
 
-use Symfony\Bundle\DoctrineAbstractBundle\Tests\TestCase;
-use Symfony\Bundle\DoctrineAbstractBundle\Tests\Common\ContainerAwareFixture;
-use Symfony\Bundle\DoctrineAbstractBundle\Common\DataFixtures\Loader;
+use Symfony\Bundle\DoctrineFixturesBundle\Tests\TestCase;
+use Symfony\Bundle\DoctrineFixturesBundle\Tests\Common\ContainerAwareFixture;
+use Symfony\Bundle\DoctrineFixturesBundle\Common\DataFixtures\Loader;
 
 class LoaderTest extends TestCase
 {

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Symfony\Bundle\DoctrineAbstractBundle\Tests;
+namespace Symfony\Bundle\DoctrineFixturesBundle\Tests;
 
 class TestCase extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Added all mising classes to the bundle, removed from core in commit:
https://github.com/symfony/symfony/commit/0632327b7781b54c02ab867431c786ed90389dfb

Renamed all namespaces to `DoctrineFixturesBundle`
