### PR TITLE
Fix for 2.0 composer package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/symfony": ">=2.0,<2.1"
+        "symfony/symfony": ">=2.0,<2.1",
+        "doctrine/data-fixtures": "*"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bundle\\DoctrineFixturesBundle": "" }


### PR DESCRIPTION
Use `Symfony` vendor for `2.0` package and require `doctrine/data-fixtures` library.
