### PR TITLE
Wrong "load" method signature

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -92,11 +92,12 @@ entry:
     namespace Acme\HelloBundle\DataFixtures\ORM;
 
     use Doctrine\Common\DataFixtures\FixtureInterface;
+    use Doctrine\Common\Persistence\ObjectManager;
     use Acme\HelloBundle\Entity\User;
 
     class LoadUserData implements FixtureInterface
     {
-        public function load($manager)
+        public function load(ObjectManager $manager)
         {
             $userAdmin = new User();
             $userAdmin->setUsername('admin');


### PR DESCRIPTION
In order to keep the same method's signature between our class load method and the FixtureInterface, ObjectManager must be specified as type hinting.

Since this : https://github.com/doctrine/data-fixtures/blob/1832b99ee57a427fc7ab432d3ebe30c00c5ab9d2/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
