### PR TITLE
Fixed indentation of the `conmposer.json` content

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -18,11 +18,11 @@ If you're using the Standard Distribution, add the following to your
 
 .. code-block:: json
 
-{
-    "require": {
-        "doctrine/doctrine-fixtures-bundle": "dev-master"
+    {
+        "require": {
+            "doctrine/doctrine-fixtures-bundle": "dev-master"
+        }
     }
-}
 
 Update the vendor libraries:
 


### PR DESCRIPTION
It fixes the display of this [doc](http://symfony.com/doc/master/bundles/DoctrineFixturesBundle/index.html) on Symfony docs.
