### PR TITLE
added the --no-confirmation option

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -41,6 +41,7 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
             ->addOption('append', null, InputOption::VALUE_NONE, 'Append the data fixtures instead of deleting all data from the database first.')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
             ->addOption('purge-with-truncate', null, InputOption::VALUE_NONE, 'Purge data by using a database-level TRUNCATE statement')
+            ->addOption('no-confirmation', null, InputOption::VALUE_NONE, 'Do not ask for a confirmation when purging the database')
             ->setHelp(<<<EOT
 The <info>doctrine:fixtures:load</info> command loads data fixtures from your bundles:
 
@@ -68,7 +69,7 @@ EOT
         $doctrine = $this->getContainer()->get('doctrine');
         $em = $doctrine->getManager($input->getOption('em'));
 
-        if ($input->isInteractive() && !$input->getOption('append')) {
+        if ($input->isInteractive() && !$input->getOption('append') && !$input->getOption('no-confirmation')) {
             $dialog = $this->getHelperSet()->get('dialog');
             if (!$dialog->askConfirmation($output, '<question>Careful, database will be purged. Do you want to continue Y/N ?</question>', false)) {
                 return;


### PR DESCRIPTION
The new interactive confirmation for the database purge action makes sense.
But in some case it could be a problem, with capifony for example. I have a staging dev version, and I rebuild the db on every deploy. With this option I'm unable to deploy, and --append is not a viable option.

The --no-confirmation option bypass the check and purge the db even if in interative mode.
