### PR TITLE
Allow fixture classes to be loaded individually.

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -140,6 +140,9 @@ Both commands come with a few options:
 * ``--fixtures=/path/to/fixture`` - Use this option to manually specify the
   directory where the fixtures classes should be loaded;
 
+* ``--fixture-classes=ClassName/Of/Fixture`` - Use this option to manualy specify the
+  class of the fixtures that should be loaded (replace ``\`` in class name with ``/``);
+
 * ``--append`` - Use this flag to append data instead of deleting data before
   loading it (deleting first is the default behavior);
 


### PR DESCRIPTION
This pull requests allows to load individual fixture classes by their class names by adding `--fixture-classes` option.

In some projects which require various fixture sets (e.g. for different setups for various environments) being able to point fixtures only by directory is quite a pain as some fixtures may be reused in few sets. Moving them to subdirectories doesn't solve the problem in some cases as namespaces would have to be adjusted accordingly and code would have to be duplicated. There were some issues reported concerning the lack of this feature both in this repo and in data-fixtures.

I have made a similar pull request https://github.com/doctrine/data-fixtures/pull/79 to data-fixtures  to allow loading individual files instead of directories and I was hoping to add this behaviour also to DoctrineFixturesBundle, but the pull request hasn't been merged yet. This pull request is another way to add similar (or maybe even better) functionality directly to DoctrineFixturesBundle, as `addFixture` method is already available in data-fixtures `Loader` class.