### PR TITLE
Installation: update single package

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -20,7 +20,7 @@ Standard edition. Add the following to your ``composer.json`` file:
 
     {
         "require": {
-            "doctrine/doctrine-fixtures-bundle": "dev-master"
+            "doctrine/doctrine-fixtures-bundle": "@dev"
         }
     }
 
@@ -28,7 +28,7 @@ Update the vendor libraries:
 
 .. code-block:: bash
 
-    $ php composer.phar update
+    $ php composer.phar update doctrine/doctrine-fixtures-bundle
 
 If everything worked, the ``DoctrineFixturesBundle`` can now be found
 at ``vendor/doctrine/doctrine-fixtures-bundle``.


### PR DESCRIPTION
Updated instruction to use `DoctrineFixturesBundle` in Symfony 2.1.4.
