### PR TITLE
Fix documentation (add "use" statement)

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -303,6 +303,7 @@ component when checking it:
     namespace Acme\HelloBundle\DataFixtures\ORM;
 
     use Doctrine\Common\DataFixtures\FixtureInterface;
+    use Doctrine\Common\Persistence\ObjectManager;
     use Symfony\Component\DependencyInjection\ContainerAwareInterface;
     use Symfony\Component\DependencyInjection\ContainerInterface;
     use Acme\HelloBundle\Entity\User;


### PR DESCRIPTION
I was going through the tutorial and I kept getting a strang PHP error.

I found out, on stackoverflow:
http://stackoverflow.com/questions/9295669/load-declaration-must-be-compatible-with-fixtureinterfaceload

that the reason for this error was that the "use" statement was missing. This change adds the use statement to the documentation. :)

thanks!
