### PR TITLE
Update Resources/doc/index.rst

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -20,7 +20,8 @@ Standard edition. Add the following to your ``composer.json`` file:
 
     {
         "require": {
-            "doctrine/doctrine-fixtures-bundle": "dev-master"
+            "doctrine/doctrine-fixtures-bundle": "dev-master",
+            "doctrine/data-fixtures": "@dev"
         }
     }
 


### PR DESCRIPTION
Most people use the default minimum-stability: "stable". Make sure they can install data-fixtures anyway.
