### PR TITLE
Annotated Fixtures

### DIFF
--- a/Annotation/Fixture.php
+++ b/Annotation/Fixture.php
@@ -16,16 +16,18 @@ class Fixture
         if (array_key_exists('value', $data)) {
             $value = $data['value'];
 
-            if (!is_array($value))
+            if (!is_array($value)) {
                 $value = array($value);
+            }
 
             $this->env = $value;
         }
 
         if (array_key_exists('env', $data)) {
             $env = $data['env'];
-            if (!is_array($env))
+            if (!is_array($env)) {
                 $env = array($env);
+            }
 
             $this->env = $env;
         }

--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -25,7 +25,12 @@ use Doctrine\Common\Annotations\Reader;
 use InvalidArgumentException;
 use ReflectionClass;
 
-
+/**
+ * Load data fixtures from bundles.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Jonathan H. Wage <jonwage@gmail.com>
+ */
 class LoadDataFixturesDoctrineCommand extends DoctrineCommand
 {
     protected function configure()
@@ -55,7 +60,7 @@ the database. If you want to use a TRUNCATE statement instead you can use the <i
 
   <info>./app/console doctrine:fixtures:load --purge-with-truncate</info>
 EOT
-            );
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -77,9 +82,7 @@ EOT
                     $paths[] = $path;
                 }
             }
-        }
-        else
-        {
+        } else {
             foreach ($fixtures as $fixture) {
                 if (!file_exists($fixture)) {
                     throw new InvalidArgumentException('Fixture ' . $fixture . ' not found');
@@ -87,8 +90,7 @@ EOT
 
                 if (is_dir($fixture)) {
                     $paths[] = $fixture;
-                }
-                else {
+                } else {
                     $files[] = $fixture;
                 }
             }
@@ -96,8 +98,7 @@ EOT
 
         $fixtures = array();
         $files    = array_merge($files, $this->getFiles($paths));
-        foreach ($files as $file)
-        {
+        foreach ($files as $file) {
             $className = $this->getClassName($file);
             $reflection = new ReflectionClass($className);
             $annotation = $reader->getClassAnnotation($reflection, 'Doctrine\Bundle\FixturesBundle\Annotation\Fixture');


### PR DESCRIPTION
Backward compability: no (but could be added)

Example, how fixtures could look like, if this PR would be accepted:

``` php
/**
 * @Fixture("dev", order=100)
 */
class LoadUsers implements FixtureInterface
{
    function load(ObjectManager $manager)
    {
        // some stuff
    }
}
```

or

``` php
/**
 * @Fixture(env={"dev", "prod"})
 * Not giving any order could imply order=0
 */
class LoadUsers implements FixtureInterface
{
    function load(ObjectManager $manager)
    {
        // some stuff
    }
}
```

See also #76
