### PR TITLE
[Dependencies] - data-fixtures not found by composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=5.3.2",
         "symfony/doctrine-bridge": ">=2.1.0,<2.3-dev",
         "doctrine/doctrine-bundle": "~1.0",
-        "doctrine/data-fixtures": "*"
+        "doctrine/data-fixtures": "dev-master"
     },
     "autoload": {
         "psr-0": { "Doctrine\\Bundle\\FixturesBundle": "" }


### PR DESCRIPTION
Some times happens that composer is not able to find doctrine/data-fixtures. After investigating a bit looks like composer does not recognizes the "*" for the version when searching for doctrine/data-fixtures and if you already have them installed composer says nothing. 
Many people are solving the problem by adding the dependence by hand with:
"doctrine/data-fixtures": "dev-master" in their composer.json.

This PR aims to solve that by changing it in the composer.json of the bundle.
