### PR TITLE
Fixing extension class name & services.xml formatting

### DIFF
--- a/DependencyInjection/DoctrineFixturesExtension.php
+++ b/DependencyInjection/DoctrineFixturesExtension.php
@@ -32,7 +32,7 @@ use Symfony\Component\DependencyInjection\Loader;
  *
  * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
  */
-class FixturesExtension extends Extension
+class DoctrineFixturesExtension extends Extension
 {
     /**
      * {@inheritDoc}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -67,8 +67,9 @@
         </service>
 
         <service id="doctrine_fixtures.event_listener.container_aware_event_subscriber"
-                 class="%doctrine_fixtures.container_aware_event_subscriber.class%">
+                 class="%doctrine_fixtures.event_listener.container_aware_event_subscriber.class%">
             <tag name="doctrine_fixtures.event_manager"/>
             <argument type="service" id="service_container"/>
         </service>
+    </services>
 </container>


### PR DESCRIPTION
services.xml was not loaded as the bundle's extension class name was incorrect. Hence, services.xml formatting error wasn't showing up. This PR fixes this.
