### PR TITLE
Updated composer.json for Symfony 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/doctrine-bridge": ">=2.1.0,<2.3-dev",
+        "symfony/doctrine-bridge": ">=2.1.0,<2.4-dev",
         "doctrine/doctrine-bundle": "~1.0",
         "doctrine/data-fixtures": "*"
     },


### PR DESCRIPTION
I'm not sure if there is a bigger issue, but i've been unable to install this bundle with Symfony 2.3. I've updated composer.json but not fully tested yet.

I found the same with the migrations bundle too.
