### PR TITLE
Fixing dependency reference to an existing matching version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=5.3.2",
         "symfony/doctrine-bridge": ">=2.1.0,<2.4-dev",
         "doctrine/doctrine-bundle": "~1.0",
-        "doctrine/data-fixtures": "*"
+        "doctrine/data-fixtures": "dev-master"
     },
     "autoload": {
         "psr-0": { "Doctrine\\Bundle\\FixturesBundle": "" }


### PR DESCRIPTION
will now avoid any "doctrine/doctrine-fixtures-bundle dev-master requires doctrine/data-fixtures \* -> no matching package found." error message
