### PR TITLE
Allow fixtures loading from a single file

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -89,6 +89,8 @@ EOT
         foreach ($paths as $path) {
             if (is_dir($path)) {
                 $loader->loadFromDirectory($path);
+            } elseif (is_file($path)) {
+                $loader->loadFromFile($path);
             }
         }
         $fixtures = $loader->getFixtures();


### PR DESCRIPTION
The command ```fixtures``` option is documented as below:
> The directory or file to load data fixtures from.

In fact, it's currently impossible to load fixtures from a file.

This PR needs doctrine/data-fixtures#106 to be relevant.