### PR TITLE
Composer should only update current dependency

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -28,7 +28,7 @@ Update the vendor libraries:
 
 .. code-block:: bash
 
-    $ php composer.phar update
+    $ php composer.phar update doctrine/doctrine-fixtures-bundle
 
 If everything worked, the ``DoctrineFixturesBundle`` can now be found
 at ``vendor/doctrine/doctrine-fixtures-bundle``.


### PR DESCRIPTION
Executing `composer update` will update all composer dependencies which can lead to undesired dependencies upgrades.

Instead, we should only call composer for update the current bundle package
