### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/doctrine-bridge": "~2.1",
+        "symfony/doctrine-bridge": "~3.0",
         "doctrine/doctrine-bundle": "~1.0",
         "doctrine/data-fixtures": "~1.0"
     },


### PR DESCRIPTION
Hi,

the dependencie of this bundle on his last version "doctrine/doctrine-fixtures-bundle": "2.2.*@dev" with "doctrine-bridge" is out of date : "symfony/doctrine-bridge": "~2.1" ("2013-05-26 18:42 UTC").

Can I inject the dependencie with the last version of doctrine-bridge which is "symfony/doctrine-bridge": "3.0.*@dev" (2014-12-30 10:17 UTC) ?

Thanks stof !