### PR TITLE
Allow fixture load paths to be configured in the bundle configuration

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -95,6 +95,13 @@ EOT
             }
         }
 
+        if ($this->getContainer()->hasParameter('doctrine_fixtures.paths')) {
+            $paths = array_merge(
+                $paths,
+                $this->getContainer()->getParameter('doctrine_fixtures.paths')
+            );
+        }
+
         $loader = new DataFixturesLoader($this->getContainer());
         foreach ($paths as $path) {
             if (is_dir($path)) {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Doctrine\Bundle\FixturesBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+
+/**
+ * @author Tyler Stroud <tyler@tylerstroud.com>
+ *
+ */
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * @return TreeBuilder
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('doctrine_fixtures', 'array');
+
+        $this->addPathsConfiguration($rootNode);
+
+        return $treeBuilder;
+    }
+
+    /**
+     * @param NodeDefinition $root
+     */
+    protected function addPathsConfiguration(NodeDefinition $root)
+    {
+        $root
+            ->children()
+                ->arrayNode('paths')
+                ->info('An array of paths to where your fixtures are located.')
+                ->prototype('scalar')->end()
+            ->end();
+    }
+}

--- a/DependencyInjection/DoctrineFixturesExtension.php
+++ b/DependencyInjection/DoctrineFixturesExtension.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Doctrine\Bundle\FixturesBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+
+/**
+ * @author Tyler Stroud <tyler@tylerstroud.com>
+ */
+class DoctrineFixturesExtension extends Extension
+{
+    /**
+     * @param array            $configs
+     * @param ContainerBuilder $container
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        if (isset($config['paths'])) {
+            $container->setParameter('doctrine_fixtures.paths', $config['paths']);
+        }
+    }
+}
+

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -54,13 +54,28 @@ bundle only for the ``dev`` and ``test`` environments:
         // ...
     }
 
+Step 3 (Optional): Configure Fixture Paths
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If your fixtures live in a directory outside of the default bundle location,
+you will need to specify the path to them:
+
+.. code-block:: yaml
+
+    // app/config/config.yml
+
+    doctrine_fixtures:
+        paths:
+            - /path/to/fixtures
+            - /path/to/more/fixtures
+
 Writing Simple Fixtures
 -----------------------
 
 Doctrine2 fixtures are PHP classes where you can create objects and persist
-them to the database. Like all classes in Symfony, fixtures should live inside
-one of your application bundles.
+them to the database.
 
+If you did not configure a custom location for your fixtures, they are expected to be inside your bundles.
 For a bundle located at ``src/AppBundle``, the fixture classes should live inside
 ``src/AppBundle/DataFixtures/ORM`` or ``src/AppBundle/DataFixtures/MongoDB``
 respectively for the ORM and ODM. This tutorial assumes that you are using the ORM,

--- a/Tests/DependencyInjection/DoctrineFixturesExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineFixturesExtensionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Doctrine\Bundle\FixturesBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Tyler Stroud <tyler@tylerstroud.com>
+ */
+class DoctrineFixturesExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    protected $container;
+    protected $extension;
+
+    public function setUp()
+    {
+        $this->container = new ContainerBuilder();
+        $this->extension = new DoctrineFixturesExtension();
+    }
+
+    public function testPathsConfiguration()
+    {
+        $config = [
+            'doctrine_fixtures' => [
+                'paths' => [
+                    '/path1/',
+                    '/path2/'
+                ]
+            ]
+        ];
+
+        $this->extension->load($config, $this->container);
+        $this->assertTrue($this->container->hasParameter('doctrine_fixtures.paths'));
+        $this->assertEquals(['/path1/', '/path2/'], $this->container->getParameter('doctrine_fixtures.paths'));
+    }
+}

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
This PR adds the ability to configure an array of paths from which fixtures will be loaded.

(This was suggested in #102).
