### PR TITLE
Load fixtures from a file

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -89,6 +89,8 @@ EOT
         foreach ($paths as $path) {
             if (is_dir($path)) {
                 $loader->loadFromDirectory($path);
+            } elseif (is_file($path)) {
+                $loader->loadFromFile($path);
             }
         }
         $fixtures = $loader->getFixtures();


### PR DESCRIPTION
The command suggests that it's possible to load only one fixture file, but it ignores it.

```
$ php console doctrine:fixtures:load --env=test --fixtures="src/Crm/CrmBundle/DataFixtures/ORM/LoadGroupData.php"

  [InvalidArgumentException]
  Could not find any fixtures to load in:
  - src/Crm/CrmBundle/DataFixtures/ORM/LoadGroupData.php
```


The method `loadFromFile` has been introduced by this commit: https://github.com/doctrine/data-fixtures/commit/81cd269006b37452389801e05974ba05bcd7005b