### PR TITLE
Clarify default option in dialog confirmation

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -69,7 +69,7 @@ EOT
         $em = $doctrine->getManager($input->getOption('em'));
 
         if ($input->isInteractive() && !$input->getOption('append')) {
-            if (!$this->askConfirmation($input, $output, '<question>Careful, database will be purged. Do you want to continue Y/N ?</question>', false)) {
+            if (!$this->askConfirmation($input, $output, '<question>Careful, database will be purged. Do you want to continue y/N ?</question>', false)) {
                 return;
             }
         }


### PR DESCRIPTION
Use a lowercase `y` and uppercase `N` to indicate that no is the default option.