### PR TITLE
Add help to avoid ContextErrorException

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -286,6 +286,24 @@ by ``getOrder()``. Any object that is set with the ``setReference()`` method
 can be accessed via ``getReference()`` in fixture classes that have a higher
 order.
 
+.. note::
+
+    If you get a ``ContextErrorException`` when trying to load the fixtures, then
+    add the ``__toString()`` method to all of the corresponding entity classes:
+
+    .. code-block:: php
+
+        // src/Acme/HelloBundle/Entity/User.php
+
+        // ...
+
+        public function __toString()
+        {
+            return (string) $this->getId();
+        }
+
+        // ...
+
 Fixtures allow you to create any type of data you need via the normal PHP
 interface for creating and persisting objects. By controlling the order of
 fixtures and setting references, almost anything can be handled by fixtures.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Doc fix?      | yes
| New docs?     | no
| Applies to    | all
| Fixed tickets |

It's a common problem to get a ContextErrorException when loading
fixtures with references. Adding the __toString() method to all
corresponding entity classes solves this problem.

I added a short note on how to avoid the ContextErrorException.