### PR TITLE
Documentation: load with append option

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -102,6 +102,11 @@ Executing Fixtures
 Once your fixtures have been written, you can load them via the command
 line by using the ``doctrine:fixtures:load`` command:
 
+.. caution::
+
+    By default the ``load`` command purges the database, removing all data from every table.
+    To append your fixtures' data specify the ``--append`` option.
+
 .. code-block:: bash
 
     $ php app/console doctrine:fixtures:load


### PR DESCRIPTION
Added a caution block before the load command is introduced, warning the reader that, by default, all data is removed from every table by the load command. I accidentally blew away a development database thinking only the tables to which my fixtures applied would be purged.