### PR TITLE
Fixed wrong link references

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -5,7 +5,7 @@ Fixtures are used to load a controlled set of data into a database. This data
 can be used for testing or could be the initial data required for the
 application to run smoothly. Symfony has no built in way to manage fixtures
 but Doctrine2 has a library to help you write fixtures for the Doctrine
-:doc:`ORM</book/doctrine>` or :doc:`ODM</bundles/DoctrineMongoDBBundle/index>`.
+`ORM`_ or `ODM`_.
 
 Setup and Configuration
 -----------------------
@@ -328,6 +328,8 @@ class (as shown above), you can access it in the ``load()`` method.
     If you prefer not to implement the needed method :method:`Symfony\\Component\\DependencyInjection\\ContainerInterface::setContainer`,
     you can then extend your class with :class:`Symfony\\Component\\DependencyInjection\\ContainerAware`.
 
+.. _`ORM`: https://github.com/doctrine/doctrine2
+.. _`ODM`: https://github.com/doctrine/mongodb-odm
 .. _DoctrineFixturesBundle: https://github.com/doctrine/DoctrineFixturesBundle
 .. _`Doctrine Data Fixtures`: https://github.com/doctrine/data-fixtures
 .. _`installation chapter`: https://getcomposer.org/doc/00-intro.md


### PR DESCRIPTION
This PR fixes the following errors reported by our doc build tool:

```
index.rst:4: WARNING: unknown document: /book/doctrine
index.rst:4: WARNING: unknown document: /bundles/DoctrineMongoDBBundle/index
```
