### PR TITLE
Fixtures list command

### DIFF
--- a/Command/AbstractFixturesCommand.php
+++ b/Command/AbstractFixturesCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Fixtures Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Bundle\FixturesBundle\Command;
+
+use Doctrine\Bundle\DoctrineBundle\Command\DoctrineCommand;
+use InvalidArgumentException;
+use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader as DataFixturesLoader;
+
+/**
+ * Abstract Fixture command
+ *
+ * @author miholeus <me@miholeus.com>
+ */
+
+abstract class AbstractFixturesCommand extends DoctrineCommand
+{
+    protected $logger;
+
+    /**
+     * @param mixed $logger
+     */
+    public function setLogger($logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * Get fixtures
+     * If path is specified then fixtures will be loaded from that path
+     *
+     * @param string $dirOrFile path to fixtures
+     * @return array
+     */
+    protected function getFixtures($dirOrFile = null)
+    {
+        if ($dirOrFile) {
+            $paths = is_array($dirOrFile) ? $dirOrFile : array($dirOrFile);
+        } else {
+            $paths = array();
+            foreach ($this->getApplication()->getKernel()->getBundles() as $bundle) {
+                $paths[] = $bundle->getPath().'/DataFixtures/ORM';
+            }
+        }
+
+        $loader = new DataFixturesLoader($this->getContainer());
+        foreach ($paths as $path) {
+            if (is_dir($path)) {
+                $loader->loadFromDirectory($path);
+            } elseif (is_file($path)) {
+                $loader->loadFromFile($path);
+            }
+        }
+        $fixtures = $loader->getFixtures();
+
+        if (!$fixtures) {
+            throw new InvalidArgumentException(
+                sprintf('Could not find any fixtures to load in: %s', "\n\n- ".implode("\n- ", $paths))
+            );
+        }
+
+        return $fixtures;
+    }
+
+
+    /**
+     * Logs a message using the logger.
+     *
+     * @param string $message
+     */
+    public function log($message)
+    {
+        $logger = $this->logger;
+        $logger($message);
+    }
+}

--- a/Command/ListFixturesDoctrineCommand.php
+++ b/Command/ListFixturesDoctrineCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Fixtures Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Bundle\FixturesBundle\Command;
+
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * List fixtures from bundles.
+ *
+ * @author miholeus <me@miholeus.com>
+ */
+class ListFixturesDoctrineCommand extends AbstractFixturesCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('doctrine:fixtures:list')
+            ->setDescription('Shows list of available fixtures.')
+            ->addOption('fixtures', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The directory to load data fixtures from.')
+            ->addOption('order', null, InputOption::VALUE_OPTIONAL, 'Find fixture by specified number if OrderedFixtureInterface is implemented')
+            ->setHelp(<<<EOT
+The <info>doctrine:fixtures:list</info> command shows data fixtures from your bundles:
+
+  <info>./app/console doctrine:fixtures:list</info>
+
+You can also optionally specify the path to fixtures with the <info>--fixtures</info> option:
+
+  <info>./app/console doctrine:fixtures:list --fixtures=/path/to/fixtures1 --fixtures=/path/to/fixtures2</info>
+
+If you want to view only one fixture with specified order you can use the <info>--order</info> option:
+
+  <info>./app/console doctrine:fixtures:list --order=number</info>
+EOT
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $dirOrFile = $input->getOption('fixtures');
+        $order = $input->getOption('order');
+
+        $this->setLogger(function($message) use ($output){
+            $output->writeln(sprintf('  <comment>></comment> <info>%s</info>', $message));
+        });
+        $fixtures = $this->getFixtures($dirOrFile);
+
+        foreach ($fixtures as $fixture) {
+            $prefix = '';
+            if ($fixture instanceof OrderedFixtureInterface) {
+                if ($order && $order != $fixture->getOrder()) {// if order is set, filter by order
+                    continue;
+                }
+                $prefix = sprintf('[%d] ',$fixture->getOrder());
+            }
+            $this->log('Fixture ' . $prefix . get_class($fixture));
+        }
+    }
+}

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -141,6 +141,24 @@ A full example use might look like this:
 
    php bin/console doctrine:fixtures:load --fixtures=/path/to/fixture1 --fixtures=/path/to/fixture2 --append --em=foo_manager
 
+List of Available fixtures
+--------------------------
+
+You can view all available fixtures with the following command:
+
+.. code-block:: bash
+
+    php app/console doctrine:fixtures:list
+
+These command will show you all migrations. If your migrations use OrderedFixtureInterface, then migrations
+will be sorted by order.
+
+Command come with a few options:
+
+* ``--fixtures=/path/to/fixture`` - Use this option to manually specify the
+  directory where the fixtures classes should be loaded;
+* ``--order`` - Use this option to search for migration with selected order;
+
 Sharing Objects between Fixtures
 --------------------------------
 


### PR DESCRIPTION
Sometimes when having many fixtures you end up with lots of files and don't know which one is executed first and the second. We use `OrderedFixtureInterface` to set order explicitly, but what will you do if you need to change order of some fixture? You'll need in looking up for order in many files, that's tedious work. These PR solves that problem, you'll always see list of available migrations ordered. Also you can find migration by selected order.
So new command is added to bundle:
`doctrine:fixtures:list`
