### PR TITLE
allow overriding of services in LoadDataFixturesDoctrineCommand (branch master)

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -18,12 +18,14 @@ use Doctrine\Bundle\DoctrineBundle\Command\DoctrineCommand;
 use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\DBAL\Sharding\PoolingShardConnection;
+use Doctrine\ORM\EntityManagerInterface;
 use InvalidArgumentException;
 use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader as DataFixturesLoader;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Load data fixtures from bundles.
@@ -95,7 +97,7 @@ EOT
             }
         }
 
-        $loader = new DataFixturesLoader($this->getContainer());
+        $loader = $this->createDataFixturesLoader($this->getContainer());
         foreach ($paths as $path) {
             if (is_dir($path)) {
                 $loader->loadFromDirectory($path);
@@ -109,9 +111,9 @@ EOT
                 sprintf('Could not find any fixtures to load in: %s', "\n\n- ".implode("\n- ", $paths))
             );
         }
-        $purger = new ORMPurger($em);
+        $purger = $this->createORMPurger($em);
         $purger->setPurgeMode($input->getOption('purge-with-truncate') ? ORMPurger::PURGE_MODE_TRUNCATE : ORMPurger::PURGE_MODE_DELETE);
-        $executor = new ORMExecutor($em, $purger);
+        $executor = $this->createORMExecutor($em, $purger);
         $executor->setLogger(function ($message) use ($output) {
             $output->writeln(sprintf('  <comment>></comment> <info>%s</info>', $message));
         });
@@ -138,5 +140,33 @@ EOT
         $question = new ConfirmationQuestion($question, $default);
 
         return $questionHelper->ask($input, $output, $question);
+    }
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+     * @return \Doctrine\Common\DataFixtures\Loader
+     */
+    protected function createDataFixturesLoader(ContainerInterface $container)
+    {
+        return new DataFixturesLoader($container);
+    }
+
+    /**
+     * @param \Doctrine\ORM\EntityManagerInterface $em
+     * @return \Doctrine\Common\DataFixtures\Purger\ORMPurger
+     */
+    protected function createORMPurger(EntityManagerInterface $em)
+    {
+        return new ORMPurger($em);
+    }
+
+    /**
+     * @param \Doctrine\ORM\EntityManagerInterface $em
+     * @param \Doctrine\Common\DataFixtures\Purger\ORMPurger $purger
+     * @return \Doctrine\Common\DataFixtures\Executor\ORMExecutor
+     */
+    protected function createORMExecutor(EntityManagerInterface $em, ORMPurger $purger)
+    {
+        return new ORMExecutor($em, $purger);
     }
 }


### PR DESCRIPTION
I wanted to override something in executor, but that cannot be done without copy&pasting huge chunks of code in the command. This simple refactoring solves it.
