### PR TITLE
Add a default email

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -86,6 +86,7 @@ entry:
             $userAdmin = new User();
             $userAdmin->setUsername('admin');
             $userAdmin->setPassword('test');
+            $userAdmin->setEmail('root@example.org');
 
             $manager->persist($userAdmin);
             $manager->flush();


### PR DESCRIPTION
FOS User Bundle require a non-empty email field

``````
  [Doctrine\DBAL\Exception\NotNullConstraintViolationException]                      
  An exception occurred while executing 'INSERT INTO fos_user (username, username_c  
  anonical, email, email_canonical, enabled, salt, password, last_login, locked, ex  
  pired, expires_at, confirmation_token, password_requested_at, roles, credentials_  
  expired, credentials_expire_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,  
   ?, ?)' with params ["root", "root", null, null, 0, "3wd6msi0gi680s0skcgwg4css0wo  
  wgk", "root", null, 0, 0, null, null, null, "a:1:{i:0;s:16:\"ROLE_SUPER_ADMIN\";}  
  ", 0, null]:                                                                       
  SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'email' cannot be nu  
  ll                                                                                 



  [Doctrine\DBAL\Driver\PDOException]                                                
  SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'email' cannot be nu  
  ll                                                                                 



  [PDOException]                                                                     
  SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'email' cannot be nu  
  ll    ```
``````
