### PR TITLE
Add kernel root directory to fixtures location paths

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -89,8 +89,10 @@ EOT
         if ($dirOrFile) {
             $paths = is_array($dirOrFile) ? $dirOrFile : array($dirOrFile);
         } else {
-            $paths = array();
-            foreach ($this->getApplication()->getKernel()->getBundles() as $bundle) {
+            /** @var $kernel \Symfony\Component\HttpKernel\KernelInterface */
+            $kernel = $this->getApplication()->getKernel();
+            $paths = array($kernel->getRootDir().'/DataFixtures/ORM');
+            foreach ($kernel->getBundles() as $bundle) {
                 $paths[] = $bundle->getPath().'/DataFixtures/ORM';
             }
         }


### PR DESCRIPTION
It would be helpful to handle fixtures automatically(without specifying of path), in applications those are using MicroKernelTrait or similar ones, those do not define bundles in itself.
Small fix great profits.