### PR TITLE
Update index.rst

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -109,13 +109,13 @@ line by using the ``doctrine:fixtures:load`` command:
 
 .. code-block:: bash
 
-    php app/console doctrine:fixtures:load
+    php bin/console doctrine:fixtures:load
 
 If you're using the ODM, use the ``doctrine:mongodb:fixtures:load`` command instead:
 
 .. code-block:: bash
 
-    php app/console doctrine:mongodb:fixtures:load
+    php bin/console doctrine:mongodb:fixtures:load
 
 The task will look inside the ``DataFixtures/ORM/`` (or ``DataFixtures/MongoDB/``
 for the ODM) directory of each bundle and execute each class that implements
@@ -139,7 +139,7 @@ A full example use might look like this:
 
 .. code-block:: bash
 
-   php app/console doctrine:fixtures:load --fixtures=/path/to/fixture1 --fixtures=/path/to/fixture2 --append --em=foo_manager
+   php bin/console doctrine:fixtures:load --fixtures=/path/to/fixture1 --fixtures=/path/to/fixture2 --append --em=foo_manager  
 
 Sharing Objects between Fixtures
 --------------------------------

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -139,7 +139,7 @@ A full example use might look like this:
 
 .. code-block:: bash
 
-   php bin/console doctrine:fixtures:load --fixtures=/path/to/fixture1 --fixtures=/path/to/fixture2 --append --em=foo_manager  
+   php bin/console doctrine:fixtures:load --fixtures=/path/to/fixture1 --fixtures=/path/to/fixture2 --append --em=foo_manager
 
 Sharing Objects between Fixtures
 --------------------------------


### PR DESCRIPTION
Avoids: Fatal error: Interface 'Symfony\Component\HttpKernel\HttpKernelInterface' not found when run under Symfony 3.