### PR TITLE
Remove `--dev` option of installation

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -17,7 +17,7 @@ following command to download the latest stable version of this bundle:
 
 .. code-block:: bash
 
-    composer require --dev doctrine/doctrine-fixtures-bundle
+    composer require doctrine/doctrine-fixtures-bundle
 
 This command assumes you have Composer installed globally, as explained
 in the `installation chapter`_ of the Composer documentation.


### PR DESCRIPTION
Hi, I’ve been started using Symfony 3.3, and DIC auto configurator, and I just realized DoctrineFixturesBundle document is probably obsolete.

The DIC auto configurator collects classes located in specified dir and tries to make the reflections of them.
However it must be failed with `ReflectionException` during reflecting classes in each bundles’ DataFixtures dir because `doctrine/fixture` or `doctrine/doctrine-fixtures-bundle` may not be installed on non-dev env (According to below docuement, they’d be only installed on dev).

http://symfony.com/doc/current/bundles/DoctrineFixturesBundle/index.html

Thanks.