### PR TITLE
Fix sf3.4 command autoregistration deprecation

### DIFF
--- a/DependencyInjection/DoctrineFixturesExtension.php
+++ b/DependencyInjection/DoctrineFixturesExtension.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Fixtures Bundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Bundle\FixturesBundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+class DoctrineFixturesExtension extends Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new XmlFileLoader($container, new FileLocator(dirname(__DIR__).'/Resources/config'));
+
+        $loader->load('services.xml');
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+
+        <!-- commands -->
+        <service id="doctrine.fixtures_load_command" class="Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand">
+            <tag name="console.command" command="doctrine:fixtures:load" />
+        </service>
+
+    </services>
+</container>


### PR DESCRIPTION
Fixes #204

> Auto-registration of the command "Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand" is deprecated since Symfony 3.4 and won't be supported in 4.0. Use PSR-4 based service discovery instead