### PR TITLE
hiding confusing EmptyFixture message

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -114,6 +114,14 @@ EOT
         $purger->setPurgeMode($input->getOption('purge-with-truncate') ? ORMPurger::PURGE_MODE_TRUNCATE : ORMPurger::PURGE_MODE_DELETE);
         $executor = new ORMExecutor($em, $purger);
         $executor->setLogger(function ($message) use ($output) {
+            /*
+             * Hides the "Loading ... EmptyFixture" line, which is confusing.
+             * See the Fixture::getDependencies() method for details about this.
+             */
+            if (strpos($message, 'Doctrine\\Bundle\\FixturesBundle\\EmptyFixture') !== false) {
+                return;
+            }
+
             $output->writeln(sprintf('  <comment>></comment> <info>%s</info>', $message));
         });
         $executor->execute($fixtures, $input->getOption('append'));

--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -15,6 +15,7 @@
 namespace Doctrine\Bundle\FixturesBundle\Command;
 
 use Doctrine\Bundle\DoctrineBundle\Command\DoctrineCommand;
+use Doctrine\Bundle\FixturesBundle\EmptyFixture;
 use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\DBAL\Sharding\PoolingShardConnection;
@@ -118,7 +119,7 @@ EOT
              * Hides the "Loading ... EmptyFixture" line, which is confusing.
              * See the Fixture::getDependencies() method for details about this.
              */
-            if (strpos($message, 'Doctrine\\Bundle\\FixturesBundle\\EmptyFixture') !== false) {
+            if (strpos($message, EmptyFixture::class) !== false) {
                 return;
             }
 


### PR DESCRIPTION
Fixes #206 

Due to our workaround with the EmptyFixture stuff, you confusingly see an EmptyFixture class loaded. Hopefully some time we can get the PR merged into the `data-fixtures` library and remove this hack. But for now, I propose hiding the message. This fixture does *nothing*, so there is no reason for the user to know about it.