### PR TITLE
[3.0] Fix DependentFixtureInterface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
     # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
     - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-stable --quiet; fi
     - travis_retry composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction
+    - travis_retry composer show
 
 script:
     - ./vendor/bin/simple-phpunit

--- a/DependencyInjection/CompilerPass/FixturesCompilerPass.php
+++ b/DependencyInjection/CompilerPass/FixturesCompilerPass.php
@@ -30,8 +30,11 @@ final class FixturesCompilerPass implements CompilerPassInterface
         $definition = $container->getDefinition('doctrine.fixtures.loader');
         $taggedServices = $container->findTaggedServiceIds(self::FIXTURE_TAG);
 
+        $fixtures = [];
         foreach ($taggedServices as $serviceId => $tags) {
-            $definition->addMethodCall('addFixture', [new Reference($serviceId)]);
+            $fixtures[] = new Reference($serviceId);
         }
+
+        $definition->addMethodCall('addFixtures', [$fixtures]);
     }
 }


### PR DESCRIPTION
Fixes #215

## Problem

It seems like a racy condition with the `DependentFixtureInterface`. 

I think this is the issue:
* Every fixture is tagged with `doctrine.fixture.orm` (also the fixtures that are dependencies of others
* When the container gets created, it will do the following for the `SymfonyFixturesLoader` service:
  - Find all tagged fixture
  - For every fixture add a method call `addFixture()`
  - So it will look like this:
```php
$a = SymfonyFixturesLoader($this);
$a->addFixture(Fixture1);
$a->addFixture(Fixture2);
$a->addFixture(Fixture3);
$a->addFixture(Fixture4);
```
* When the application is booted, and you use the `SymfonyFixturesLoader` for the first time, it will execute all the `addFixture` calls
* `Doctrine\Common\DataFixtures\Loader::addFixture` will check if the fixture implements `DependentFixtureInterface`
 - When thats the case, it will call `Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader::createFixture`
 - That will then do a call to `Doctrine\Common\DataFixtures\Loader::getFixture` which then checks its internal `$this->fixtures` array to see if it exist, but it doesn't exist, because it's going to be added *later*

So I think it should be changed to do this:
* First load all fixtures into the `$this->fixtures` array
* Then foreach that array, and resolve all dependencies.

## How to test?

Add my forked repository to your `composer.json`:
```json
    "repositories": [
        {
            "type": "vcs",
            "url": "http://github.com/ruudk/DoctrineFixturesBundle"
        }
    ],
```

And then require it as follow:
```json
"require": {
    "doctrine/doctrine-fixtures-bundle": "dev-fix-dep as 3.0.0",
```

## How its solved

Instead of calling `addFixture` for every fixture, this PR will use an `addFixtures` (plural) method. It will load all the fixtures in memory, and then call `addFixture` on all of them. This will solve the dependency issues.