### PR TITLE
Make `doctrine.fixtures.loader` public

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -10,7 +10,7 @@
             <tag name="console.command" command="doctrine:fixtures:load" />
         </service>
 
-        <service id="doctrine.fixtures.loader" class="Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader" public="false">
+        <service id="doctrine.fixtures.loader" class="Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader" public="true">
             <argument type="service" id="service_container" />
         </service>
     </services>


### PR DESCRIPTION
I'm trying to get https://github.com/BehatExtension/DoctrineDataFixturesExtension to work with version 3.0 of this bundle.

It would help if this service was public, so that we can use this service to load all fixtures with all the dependencies.

## Related issue
https://github.com/BehatExtension/DoctrineDataFixturesExtension/issues/3