### PR TITLE
Split the framework-bundle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,16 @@
         "doctrine/doctrine-bundle": "^1.11|^2.0",
         "doctrine/orm": "^2.6.0",
         "symfony/doctrine-bridge": "^3.4|^4.1|^5.0",
-        "symfony/framework-bundle": "^3.4|^4.1|^5.0"
+        "symfony/config": "^3.4|^4.3|^5.0",
+        "symfony/console": "^3.4|^4.3|^5.0",
+        "symfony/dependency-injection": "^3.4|^4.3|^5.0",
+        "symfony/http-kernel": "^3.4|^4.3|^5.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^6.0",
         "phpunit/phpunit": "^7.4",
-        "symfony/phpunit-bridge": "^4.1|^5.0"
+        "symfony/phpunit-bridge": "^4.1|^5.0",
+        "symfony/framework-bundle": "^3.4|^4.0|^5.0"
     },
     "autoload": {
         "psr-4": { "Doctrine\\Bundle\\FixturesBundle\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,7 @@
     "require-dev": {
         "doctrine/coding-standard": "^6.0",
         "phpunit/phpunit": "^7.4",
-        "symfony/phpunit-bridge": "^4.1|^5.0",
-        "symfony/framework-bundle": "^3.4|^4.0|^5.0"
+        "symfony/phpunit-bridge": "^4.1|^5.0"
     },
     "autoload": {
         "psr-4": { "Doctrine\\Bundle\\FixturesBundle\\": "" }


### PR DESCRIPTION
Remove the dependency on the doctrine bundle (as the only use was in the command, and none of the helpers from the `DoctrineCommand` were used), and replace the framework-bundle dependency with the config, dic and http-kernel instead.

I kept the fw-bundle dependency in dev env, because the tests need it.

Should fix #224 