### PR TITLE
Ability to load only one fixture class

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -8,11 +8,9 @@ use Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader;
 use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\DBAL\Sharding\PoolingShardConnection;
-use InvalidArgumentException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**

--- a/Tests/IntegrationTest.php
+++ b/Tests/IntegrationTest.php
@@ -53,7 +53,7 @@ class IntegrationTest extends TestCase
         $this->assertInstanceOf(WithDependenciesFixtures::class, $actualFixtures[1]);
     }
 
-    public function testFixturesLoaderWhenFixtureHasDepdencenyThatIsNotYetLoaded()
+    public function testFixturesLoaderWhenFixtureHasDependencyThatIsNotYetLoaded()
     {
         // See https://github.com/doctrine/DoctrineFixturesBundle/issues/215
 


### PR DESCRIPTION
I think it can be useful to load only one fixture class. I make it simple and a fixture who is single cannot be a fixture ordered or cannot have dependencies. I've also fix somes typos.