### PR TITLE
Enhance system to allow only executing some fixtures via an interface

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -38,7 +38,7 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
             ->setName('doctrine:fixtures:load')
             ->setDescription('Load data fixtures to your database')
             ->addOption('append', null, InputOption::VALUE_NONE, 'Append the data fixtures instead of deleting all data from the database first.')
-            ->addOption('set', null, InputOption::VALUE_OPTIONAL, 'Only fixtures with this set attribute to the doctrine.fixtures.loader tag will be loaded')
+            ->addOption('groups', null, InputOption::VALUE_IS_ARRAY|InputOption::VALUE_OPTIONAL, 'Only fixtures with the following group attributes and the doctrine.fixtures.loader tag will be loaded')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
             ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.')
             ->addOption('purge-with-truncate', null, InputOption::VALUE_NONE, 'Purge data by using a database-level TRUNCATE statement')
@@ -85,7 +85,7 @@ EOT
             $em->getConnection()->connect($input->getOption('shard'));
         }
 
-        $fixtures = $this->fixturesLoader->getFixtures($input->getOption('set'));
+        $fixtures = $this->fixturesLoader->getFixtures($input->getOption('groups'));
         if (!$fixtures) {
             $ui->error('Could not find any fixture services to load.');
 

--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -38,6 +38,7 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
             ->setName('doctrine:fixtures:load')
             ->setDescription('Load data fixtures to your database')
             ->addOption('append', null, InputOption::VALUE_NONE, 'Append the data fixtures instead of deleting all data from the database first.')
+            ->addOption('set', null, InputOption::VALUE_OPTIONAL, 'Only fixtures with this set attribute to the doctrine.fixtures.loader tag will be loaded')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
             ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.')
             ->addOption('purge-with-truncate', null, InputOption::VALUE_NONE, 'Purge data by using a database-level TRUNCATE statement')
@@ -84,7 +85,7 @@ EOT
             $em->getConnection()->connect($input->getOption('shard'));
         }
 
-        $fixtures = $this->fixturesLoader->getFixtures();
+        $fixtures = $this->fixturesLoader->getFixtures($input->getOption('set'));
         if (!$fixtures) {
             $ui->error('Could not find any fixture services to load.');
 

--- a/DependencyInjection/CompilerPass/FixturesCompilerPass.php
+++ b/DependencyInjection/CompilerPass/FixturesCompilerPass.php
@@ -21,7 +21,10 @@ final class FixturesCompilerPass implements CompilerPassInterface
 
         $fixtures = [];
         foreach ($taggedServices as $serviceId => $tags) {
-            $fixtures[] = new Reference($serviceId);
+            $fixtures[] = [
+                'fixture' => new Reference($serviceId),
+                'tags' => $tags
+            ];
         }
 
         $definition->addMethodCall('addFixtures', [$fixtures]);

--- a/DependencyInjection/CompilerPass/FixturesCompilerPass.php
+++ b/DependencyInjection/CompilerPass/FixturesCompilerPass.php
@@ -32,7 +32,8 @@ final class FixturesCompilerPass implements CompilerPassInterface
         $definition->addMethodCall('addFixtures', [$fixtures]);
     }
 
-    private function getFixtureGroups($service, ContainerBuilder $container) {
+    private function getFixtureGroups($service, ContainerBuilder $container)
+    {
         $def = $container->getDefinition($service);
         $class = $def->getClass();
 

--- a/FixtureGroupInterface.php
+++ b/FixtureGroupInterface.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Bundle\FixturesBundle;
+
+/**
+ * GroupsInterface needs to be implemented
+ * by fixtures that belong in groups
+ *
+ * @author Noemi Quezada <nquezada@endertech.com>
+ */
+interface FixtureGroupInterface
+{
+    /**
+     * This method must return an array of groups
+     * on which the implementing class belongs to
+     *
+     * @return array
+     */
+    public static function getGroups();
+}

--- a/Loader/SymfonyFixturesLoader.php
+++ b/Loader/SymfonyFixturesLoader.php
@@ -21,7 +21,7 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader
 {
     private $loadedFixtures = [];
 
-    private $setsFixtureMapping = [];
+    private $groupsFixtureMapping = [];
 
     /**
      * @internal
@@ -32,7 +32,7 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader
         foreach ($fixtures as $fixture) {
             $class = get_class($fixture['fixture']);
             $this->loadedFixtures[$class] = $fixture['fixture'];
-            $this->addSetsFixtureMapping($class, $fixture['tags']);
+            $this->addGroupsFixtureMapping($class, $fixture['groups']);
         }
 
         // Now load all the fixtures
@@ -82,19 +82,21 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader
     /**
      * Returns the array of data fixtures to execute.
      *
-     * @param string $set
+     * @param array $groups
      *
      * @return array $fixtures
      */
-    public function getFixtures($set = null)
+    public function getFixtures(array $groups = [])
     {
         $fixtures = parent::getFixtures();
 
-        if ($set) {
+        if (!empty($groups)) {
             $filteredFixtures = [];
             foreach ($fixtures as $key => $fixture) {
-                if (isset($this->setsFixtureMapping[$set][get_class($fixture)])) {
-                    $filteredFixtures[$key] = $fixture;
+                foreach ($groups as $group) {
+                    if (isset($this->groupsFixtureMapping[$group][get_class($fixture)])) {
+                        $filteredFixtures[$key] = $fixture;
+                    }
                 }
             }
             $fixtures = $filteredFixtures;
@@ -104,19 +106,17 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader
     }
 
     /**
-     * Creates an array of the sets and there fixtures
+     * Generates an array of the groups and their fixtures
      *
      * @param string $className
-     * @param array $tags
+     * @param array $groups
      *
      * @return void
      */
-    public function addSetsFixtureMapping($className, array $tags)
+    public function addGroupsFixtureMapping($className, array $groups)
     {
-        foreach ($tags as $attributes) {
-            if (array_key_exists('set', $attributes)) {
-                $this->setsFixtureMapping[$attributes['set']][$className] = true;
-            }
+        foreach ($groups as $group) {
+            $this->groupsFixtureMapping[$group][$className] = true;
         }
     }
 

--- a/Tests/Fixtures/FooBundle/DataFixtures/OtherFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/OtherFixtures.php
@@ -2,13 +2,19 @@
 
 namespace Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures;
 
+use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 
-class OtherFixtures implements ORMFixtureInterface
+class OtherFixtures implements ORMFixtureInterface, FixtureGroupInterface
 {
     public function load(ObjectManager $manager)
     {
         // ...
+    }
+
+    public static function getGroups()
+    {
+        return ['staging'];
     }
 }

--- a/Tests/IntegrationTest.php
+++ b/Tests/IntegrationTest.php
@@ -146,12 +146,12 @@ class IntegrationTest extends TestCase
         $loader->getFixtures();
     }
 
-    public function testFixturesLoaderWithSetOption()
+    public function testFixturesLoaderWithGroupsOption()
     {
         $kernel = new IntegrationTestKernel('dev', true);
         $kernel->addServices(function(ContainerBuilder $c) {
             $c->autowire(OtherFixtures::class)
-              ->addTag(FixturesCompilerPass::FIXTURE_TAG, ['set' => 'staging']);
+              ->addTag(FixturesCompilerPass::FIXTURE_TAG);
 
             $c->autowire(WithDependenciesFixtures::class)
               ->addTag(FixturesCompilerPass::FIXTURE_TAG);
@@ -164,7 +164,7 @@ class IntegrationTest extends TestCase
         /** @var ContainerAwareLoader $loader */
         $loader = $container->get('test.doctrine.fixtures.loader');
 
-        $actualFixtures = $loader->getFixtures('staging');
+        $actualFixtures = $loader->getFixtures(['staging']);
         $this->assertCount(1, $actualFixtures);
         $actualFixtureClasses = array_map(function($fixture) {
             return get_class($fixture);


### PR DESCRIPTION
This builds off of #255

It's the same idea, but you group your fixtures via an interface instead of tag. The improvement is developer experience, you stay in the Fixture class instead of needing to re-register the service in order to give it the tag.