### PR TITLE
Add fixture groups via a static method interface or service tags

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -38,6 +38,7 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
             ->setName('doctrine:fixtures:load')
             ->setDescription('Load data fixtures to your database')
             ->addOption('append', null, InputOption::VALUE_NONE, 'Append the data fixtures instead of deleting all data from the database first.')
+            ->addOption('set', null, InputOption::VALUE_OPTIONAL, 'Only fixtures with this set attribute to the doctrine.fixtures.loader tag will be loaded')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
             ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.')
             ->addOption('purge-with-truncate', null, InputOption::VALUE_NONE, 'Purge data by using a database-level TRUNCATE statement')
@@ -86,7 +87,7 @@ EOT
             $em->getConnection()->connect($input->getOption('shard'));
         }
 
-        $fixtures = $this->fixturesLoader->getFixtures();
+        $fixtures = $this->fixturesLoader->getFixtures($input->getOption('set'));
         if (!$fixtures) {
             $ui->error('Could not find any fixture services to load.');
 

--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -38,7 +38,7 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
             ->setName('doctrine:fixtures:load')
             ->setDescription('Load data fixtures to your database')
             ->addOption('append', null, InputOption::VALUE_NONE, 'Append the data fixtures instead of deleting all data from the database first.')
-            ->addOption('set', null, InputOption::VALUE_OPTIONAL, 'Only fixtures with this set attribute to the doctrine.fixtures.loader tag will be loaded')
+            ->addOption('groups', null, InputOption::VALUE_IS_ARRAY|InputOption::VALUE_OPTIONAL, 'Only fixtures with the following group attributes and the doctrine.fixtures.loader tag will be loaded')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
             ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.')
             ->addOption('purge-with-truncate', null, InputOption::VALUE_NONE, 'Purge data by using a database-level TRUNCATE statement')
@@ -87,7 +87,7 @@ EOT
             $em->getConnection()->connect($input->getOption('shard'));
         }
 
-        $fixtures = $this->fixturesLoader->getFixtures($input->getOption('set'));
+        $fixtures = $this->fixturesLoader->getFixtures($input->getOption('groups'));
         if (!$fixtures) {
             $ui->error('Could not find any fixture services to load.');
 

--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -38,7 +38,7 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
             ->setName('doctrine:fixtures:load')
             ->setDescription('Load data fixtures to your database')
             ->addOption('append', null, InputOption::VALUE_NONE, 'Append the data fixtures instead of deleting all data from the database first.')
-            ->addOption('groups', null, InputOption::VALUE_IS_ARRAY|InputOption::VALUE_OPTIONAL, 'Only fixtures with the following group attributes and the doctrine.fixtures.loader tag will be loaded')
+            ->addOption('group', null, InputOption::VALUE_IS_ARRAY|InputOption::VALUE_REQUIRED, 'Only load fixtures that belong to this group')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
             ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.')
             ->addOption('purge-with-truncate', null, InputOption::VALUE_NONE, 'Purge data by using a database-level TRUNCATE statement')
@@ -57,6 +57,10 @@ By default Doctrine Data Fixtures uses DELETE statements to drop the existing ro
 If you want to use a TRUNCATE statement instead you can use the <comment>--purge-with-truncate</comment> flag:
 
   <info>php %command.full_name%</info> <comment>--purge-with-truncate</comment>
+
+To execute only fixtures that live in a certain group, use:
+
+  <info>php %command.full_name%</info> <comment>--group=group1</comment>
 
 EOT
         );
@@ -87,9 +91,16 @@ EOT
             $em->getConnection()->connect($input->getOption('shard'));
         }
 
-        $fixtures = $this->fixturesLoader->getFixtures($input->getOption('groups'));
+        $groups = $input->getOption('group');
+        $fixtures = $this->fixturesLoader->getFixtures($groups);
         if (!$fixtures) {
-            $ui->error('Could not find any fixture services to load.');
+            $message = 'Could not find any fixture services to load';
+
+            if (!empty($groups)) {
+                $message .= sprintf(' in the groups (%s)', implode(', ', $groups));
+            }
+
+            $ui->error($message . '.');
 
             return 1;
         }

--- a/DependencyInjection/CompilerPass/FixturesCompilerPass.php
+++ b/DependencyInjection/CompilerPass/FixturesCompilerPass.php
@@ -21,7 +21,10 @@ final class FixturesCompilerPass implements CompilerPassInterface
 
         $fixtures = [];
         foreach ($taggedServices as $serviceId => $tags) {
-            $fixtures[] = new Reference($serviceId);
+            $fixtures[] = [
+                'fixture' => new Reference($serviceId),
+                'tags' => $tags
+            ];
         }
 
         $definition->addMethodCall('addFixtures', [$fixtures]);

--- a/DependencyInjection/CompilerPass/FixturesCompilerPass.php
+++ b/DependencyInjection/CompilerPass/FixturesCompilerPass.php
@@ -1,9 +1,7 @@
 <?php
 
-
 namespace Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass;
 
-use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -22,7 +20,7 @@ final class FixturesCompilerPass implements CompilerPassInterface
 
         $fixtures = [];
         foreach ($taggedServices as $serviceId => $tags) {
-            $groups = $this->getFixtureGroups($serviceId, $container);
+            $groups = [];
             foreach ($tags as $tagData) {
                 if (isset($tagData['group'])) {
                     $groups[] = $tagData['group'];
@@ -36,21 +34,5 @@ final class FixturesCompilerPass implements CompilerPassInterface
         }
 
         $definition->addMethodCall('addFixtures', [$fixtures]);
-    }
-
-    private function getFixtureGroups($service, ContainerBuilder $container)
-    {
-        $def = $container->getDefinition($service);
-        $class = $def->getClass();
-
-        if (!$r = $container->getReflectionClass($class)) {
-            throw new \InvalidArgumentException(sprintf('Class "%s" used for service "%s" cannot be found.', $class, $service));
-        }
-
-        if (!$r->implementsInterface(FixtureGroupInterface::class)) {
-            return [];
-        }
-
-        return $class::getGroups();
     }
 }

--- a/DependencyInjection/CompilerPass/FixturesCompilerPass.php
+++ b/DependencyInjection/CompilerPass/FixturesCompilerPass.php
@@ -32,7 +32,8 @@ final class FixturesCompilerPass implements CompilerPassInterface
         $definition->addMethodCall('addFixtures', [$fixtures]);
     }
 
-    private function getFixtureGroups($service, ContainerBuilder $container) {
+    private function getFixtureGroups($service, ContainerBuilder $container)
+    {
         $def = $container->getDefinition($service);
         $class = $def->getClass();
 

--- a/FixtureGroupInterface.php
+++ b/FixtureGroupInterface.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Bundle\FixturesBundle;
+
+/**
+ * FixtureGroupInterface can to be implemented by fixtures that belong in groups
+ */
+interface FixtureGroupInterface
+{
+    /**
+     * This method must return an array of groups
+     * on which the implementing class belongs to
+     *
+     * @return array
+     */
+    public static function getGroups();
+}

--- a/FixtureGroupInterface.php
+++ b/FixtureGroupInterface.php
@@ -13,5 +13,5 @@ interface FixtureGroupInterface
      *
      * @return string[]
      */
-    public static function getGroups();
+    public static function getGroups(): array;
 }

--- a/FixtureGroupInterface.php
+++ b/FixtureGroupInterface.php
@@ -1,21 +1,4 @@
 <?php
-/*
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- * This software consists of voluntary contributions made by many individuals
- * and is licensed under the MIT license. For more information, see
- * <http://www.doctrine-project.org>.
- */
 
 namespace Doctrine\Bundle\FixturesBundle;
 
@@ -28,7 +11,7 @@ interface FixtureGroupInterface
      * This method must return an array of groups
      * on which the implementing class belongs to
      *
-     * @return array
+     * @return string[]
      */
     public static function getGroups();
 }

--- a/Loader/SymfonyFixturesLoader.php
+++ b/Loader/SymfonyFixturesLoader.php
@@ -81,34 +81,35 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader
     /**
      * Returns the array of data fixtures to execute.
      *
-     * @param array $groups
+     * @param string[] $groups
      *
-     * @return array $fixtures
+     * @return FixtureInterface[]
      */
     public function getFixtures(array $groups = [])
     {
         $fixtures = parent::getFixtures();
 
-        if (!empty($groups)) {
-            $filteredFixtures = [];
-            foreach ($fixtures as $key => $fixture) {
-                foreach ($groups as $group) {
-                    if (isset($this->groupsFixtureMapping[$group][get_class($fixture)])) {
-                        $filteredFixtures[$key] = $fixture;
-                    }
-                }
-            }
-            $fixtures = $filteredFixtures;
+        if (empty($groups)) {
+            return $fixtures;
         }
 
-        return $fixtures;
+        $filteredFixtures = [];
+        foreach ($fixtures as $key => $fixture) {
+            foreach ($groups as $group) {
+                if (isset($this->groupsFixtureMapping[$group][get_class($fixture)])) {
+                    $filteredFixtures[$key] = $fixture;
+                }
+            }
+        }
+
+        return $filteredFixtures;
     }
 
     /**
      * Generates an array of the groups and their fixtures
      *
      * @param string $className
-     * @param array $groups
+     * @param string[] $groups
      *
      * @return void
      */

--- a/Loader/SymfonyFixturesLoader.php
+++ b/Loader/SymfonyFixturesLoader.php
@@ -21,7 +21,7 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader
 {
     private $loadedFixtures = [];
 
-    private $setsFixtureMapping = [];
+    private $groupsFixtureMapping = [];
 
     /**
      * @internal
@@ -32,7 +32,7 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader
         foreach ($fixtures as $fixture) {
             $class = get_class($fixture['fixture']);
             $this->loadedFixtures[$class] = $fixture['fixture'];
-            $this->addSetsFixtureMapping($class, $fixture['tags']);
+            $this->addGroupsFixtureMapping($class, $fixture['groups']);
         }
 
         // Now load all the fixtures
@@ -76,19 +76,21 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader
     /**
      * Returns the array of data fixtures to execute.
      *
-     * @param string $set
+     * @param array $groups
      *
      * @return array $fixtures
      */
-    public function getFixtures($set = null)
+    public function getFixtures(array $groups = [])
     {
         $fixtures = parent::getFixtures();
 
-        if ($set) {
+        if (!empty($groups)) {
             $filteredFixtures = [];
             foreach ($fixtures as $key => $fixture) {
-                if (isset($this->setsFixtureMapping[$set][get_class($fixture)])) {
-                    $filteredFixtures[$key] = $fixture;
+                foreach ($groups as $group) {
+                    if (isset($this->groupsFixtureMapping[$group][get_class($fixture)])) {
+                        $filteredFixtures[$key] = $fixture;
+                    }
                 }
             }
             $fixtures = $filteredFixtures;
@@ -98,19 +100,17 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader
     }
 
     /**
-     * Creates an array of the sets and there fixtures
+     * Generates an array of the groups and their fixtures
      *
      * @param string $className
-     * @param array $tags
+     * @param array $groups
      *
      * @return void
      */
-    public function addSetsFixtureMapping($className, array $tags)
+    public function addGroupsFixtureMapping($className, array $groups)
     {
-        foreach ($tags as $attributes) {
-            if (array_key_exists('set', $attributes)) {
-                $this->setsFixtureMapping[$attributes['set']][$className] = true;
-            }
+        foreach ($groups as $group) {
+            $this->groupsFixtureMapping[$group][$className] = true;
         }
     }
 }

--- a/Loader/SymfonyFixturesLoader.php
+++ b/Loader/SymfonyFixturesLoader.php
@@ -12,6 +12,7 @@ use Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesComp
 use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\DataFixtures\FixtureInterface;
+use ReflectionClass;
 use RuntimeException;
 use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
 use function array_key_exists;
@@ -53,6 +54,9 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader
     {
         $class = get_class($fixture);
         $this->loadedFixtures[$class] = $fixture;
+
+        $reflection = new ReflectionClass($fixture);
+        $this->addGroupsFixtureMapping($class, [$reflection->getShortName()]);
 
         if ($fixture instanceof FixtureGroupInterface) {
             $this->addGroupsFixtureMapping($class, $fixture::getGroups());

--- a/Loader/SymfonyFixturesLoader.php
+++ b/Loader/SymfonyFixturesLoader.php
@@ -21,6 +21,8 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader
 {
     private $loadedFixtures = [];
 
+    private $setsFixtureMapping = [];
+
     /**
      * @internal
      */
@@ -28,7 +30,9 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader
     {
         // Store all loaded fixtures so that we can resolve the dependencies correctly.
         foreach ($fixtures as $fixture) {
-            $this->loadedFixtures[get_class($fixture)] = $fixture;
+            $class = get_class($fixture['fixture']);
+            $this->loadedFixtures[$class] = $fixture['fixture'];
+            $this->addSetsFixtureMapping($class, $fixture['tags']);
         }
 
         // Now load all the fixtures
@@ -37,6 +41,9 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader
         }
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function addFixture(FixtureInterface $fixture)
     {
         $class = get_class($fixture);
@@ -64,5 +71,46 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader
         }
 
         return $this->loadedFixtures[$class];
+    }
+
+    /**
+     * Returns the array of data fixtures to execute.
+     *
+     * @param string $set
+     *
+     * @return array $fixtures
+     */
+    public function getFixtures($set = null)
+    {
+        $fixtures = parent::getFixtures();
+
+        if ($set) {
+            $filteredFixtures = [];
+            foreach ($fixtures as $key => $fixture) {
+                if (isset($this->setsFixtureMapping[$set][get_class($fixture)])) {
+                    $filteredFixtures[$key] = $fixture;
+                }
+            }
+            $fixtures = $filteredFixtures;
+        }
+
+        return $fixtures;
+    }
+
+    /**
+     * Creates an array of the sets and there fixtures
+     *
+     * @param string $className
+     * @param array $tags
+     *
+     * @return void
+     */
+    public function addSetsFixtureMapping($className, array $tags)
+    {
+        foreach ($tags as $attributes) {
+            if (array_key_exists('set', $attributes)) {
+                $this->setsFixtureMapping[$attributes['set']][$className] = true;
+            }
+        }
     }
 }

--- a/Loader/SymfonyFixturesLoader.php
+++ b/Loader/SymfonyFixturesLoader.php
@@ -120,12 +120,9 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader
     /**
      * Generates an array of the groups and their fixtures
      *
-     * @param string $className
      * @param string[] $groups
-     *
-     * @return void
      */
-    public function addGroupsFixtureMapping($className, array $groups)
+    private function addGroupsFixtureMapping(string $className, array $groups): void
     {
         foreach ($groups as $group) {
             $this->groupsFixtureMapping[$group][$className] = true;

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -20,7 +20,7 @@ following command to download the latest stable version of this bundle:
 
     If you are using flex you just need to do:
     ``composer req --dev orm-fixtures``
-    
+
 If you're *not* using Symfony Flex (i.e. Symfony 3 and lower), you will
 also need to enable the bundle in your ``AppKernel`` class:
 
@@ -240,6 +240,45 @@ an array of the fixture classes that must be loaded before this one:
             );
         }
     }
+
+Fixture Groups: Only Executing Some Fixtures
+--------------------------------------------
+
+By default, *all* of your fixture classes are executed. If you only want
+to execute *some* of your fixture classes, you can organize them into
+groups.
+
+The simplest way to organize a fixture class into a group is to
+make your fixture implement ``FixtureGroupInterface``::
+
+    // src/DataFixtures/UserFixtures.php
+
+    + use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
+
+    - class UserFixtures extends Fixture
+    + class UserFixtures extends Fixture implements FixtureGroupInterface
+    {
+        // ...
+
+    +     public static function getGroups()
+    +     {
+    +         return ['group1', 'group2'];
+    +     }
+    }
+
+To execute all of your fixtures for a given group, pass the ``--group``
+option:
+
+.. code-block:: bash
+
+    $ php bin/console doctrine:fixtures:load --group=group1
+
+    # or to execute multiple groups
+    $ php bin/console doctrine:fixtures:load --group=group1 --group=group2
+
+Alternatively, instead of implementing the ``FixtureGroupInterface``,
+you can also tag your service with ``doctrine.fixture.orm`` and add
+an extra ``group`` option set to a group your fixture should belong to.
 
 .. _`ORM`: https://symfony.com/doc/current/doctrine.html
 .. _`installation chapter`: https://getcomposer.org/doc/00-intro.md

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -280,6 +280,15 @@ Alternatively, instead of implementing the ``FixtureGroupInterface``,
 you can also tag your service with ``doctrine.fixture.orm`` and add
 an extra ``group`` option set to a group your fixture should belong to.
 
+Regardless of groups defined in the fixture or the service definition, the
+fixture loader always adds the short name of the class as a separate group so
+you can load a single fixture at a time. In the example above, you can load the
+fixture using the ``UserFixtures`` group:
+
+.. code-block:: bash
+
+    $ php bin/console doctrine:fixtures:load --group=UserFixtures
+
 .. _`ORM`: https://symfony.com/doc/current/doctrine.html
 .. _`installation chapter`: https://getcomposer.org/doc/00-intro.md
 .. _`default service configuration`: https://symfony.com/doc/current/service_container.html#service-container-services-load-example

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -260,7 +260,7 @@ make your fixture implement ``FixtureGroupInterface``::
     {
         // ...
 
-    +     public static function getGroups()
+    +     public static function getGroups(): array
     +     {
     +         return ['group1', 'group2'];
     +     }

--- a/Tests/Fixtures/FooBundle/DataFixtures/OtherFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/OtherFixtures.php
@@ -2,13 +2,19 @@
 
 namespace Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures;
 
+use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 
-class OtherFixtures implements ORMFixtureInterface
+class OtherFixtures implements ORMFixtureInterface, FixtureGroupInterface
 {
     public function load(ObjectManager $manager)
     {
         // ...
+    }
+
+    public static function getGroups()
+    {
+        return ['staging'];
     }
 }

--- a/Tests/Fixtures/FooBundle/DataFixtures/OtherFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/OtherFixtures.php
@@ -13,7 +13,7 @@ class OtherFixtures implements ORMFixtureInterface, FixtureGroupInterface
         // ...
     }
 
-    public static function getGroups()
+    public static function getGroups(): array
     {
         return ['staging', 'fulfilledDependencyGroup'];
     }

--- a/Tests/Fixtures/FooBundle/DataFixtures/OtherFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/OtherFixtures.php
@@ -15,6 +15,6 @@ class OtherFixtures implements ORMFixtureInterface, FixtureGroupInterface
 
     public static function getGroups()
     {
-        return ['staging'];
+        return ['staging', 'fulfilledDependencyGroup'];
     }
 }

--- a/Tests/Fixtures/FooBundle/DataFixtures/WithDependenciesFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/WithDependenciesFixtures.php
@@ -2,11 +2,12 @@
 
 namespace Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures;
 
+use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 
-class WithDependenciesFixtures implements ORMFixtureInterface, DependentFixtureInterface
+class WithDependenciesFixtures implements ORMFixtureInterface, DependentFixtureInterface, FixtureGroupInterface
 {
     public function load(ObjectManager $manager)
     {
@@ -18,5 +19,10 @@ class WithDependenciesFixtures implements ORMFixtureInterface, DependentFixtureI
         return [
             OtherFixtures::class,
         ];
+    }
+
+    public static function getGroups()
+    {
+        return ['missingDependencyGroup', 'fulfilledDependencyGroup'];
     }
 }

--- a/Tests/Fixtures/FooBundle/DataFixtures/WithDependenciesFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/WithDependenciesFixtures.php
@@ -21,7 +21,7 @@ class WithDependenciesFixtures implements ORMFixtureInterface, DependentFixtureI
         ];
     }
 
-    public static function getGroups()
+    public static function getGroups(): array
     {
         return ['missingDependencyGroup', 'fulfilledDependencyGroup'];
     }

--- a/Tests/IntegrationTest.php
+++ b/Tests/IntegrationTest.php
@@ -146,12 +146,12 @@ class IntegrationTest extends TestCase
         $loader->getFixtures();
     }
 
-    public function testFixturesLoaderWithSetOption()
+    public function testFixturesLoaderWithGroupsOption()
     {
         $kernel = new IntegrationTestKernel('dev', true);
         $kernel->addServices(function(ContainerBuilder $c) {
             $c->autowire(OtherFixtures::class)
-              ->addTag(FixturesCompilerPass::FIXTURE_TAG, ['set' => 'staging']);
+              ->addTag(FixturesCompilerPass::FIXTURE_TAG);
 
             $c->autowire(WithDependenciesFixtures::class)
               ->addTag(FixturesCompilerPass::FIXTURE_TAG);
@@ -164,7 +164,7 @@ class IntegrationTest extends TestCase
         /** @var ContainerAwareLoader $loader */
         $loader = $container->get('test.doctrine.fixtures.loader');
 
-        $actualFixtures = $loader->getFixtures('staging');
+        $actualFixtures = $loader->getFixtures(['staging']);
         $this->assertCount(1, $actualFixtures);
         $actualFixtureClasses = array_map(function($fixture) {
             return get_class($fixture);


### PR DESCRIPTION
Hi guys!

This combines the nice work from #255 and #256 to add "groups" of fixtures to be loaded via a `--group=foo` flag on the command.

A fixture can be added to a group either via a `getGroups()` method on the class itself, or a `group` attribute on a service tag. This is very consistent with other patterns in Symfony - e.g. how command names can be set via a static property or as a service tag.

There is a strong IntegrationTest for this feature and I just tried it "in the wild" in a project. It works :).

Replaces #246 and #250.

Cheers!