### PR TITLE
Show the name of the database being purged when loading fixtures

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -71,7 +71,7 @@ EOT
         $em = $doctrine->getManager($input->getOption('em'));
 
         if ($input->isInteractive() && !$input->getOption('append')) {
-            if (!$this->askConfirmation($input, $output, '<question>Careful, database will be purged. Do you want to continue y/N ?</question>', false)) {
+            if (!$this->askConfirmation($input, $output, sprintf("<question>Careful, database '%s' will be purged. Do you want to continue y/N ?</question>", $em->getConnection()->getDatabase()), false)) {
                 return;
             }
         }


### PR DESCRIPTION
When working with multiple environments in Symfony and regularily reloading fixtures, it would be a useful addition to show the name of the database that's being purged before doing so. This can be a helpful last reminder to let you know if you are in the right environment and the system selected the right database.