### PR TITLE
Fix build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,13 @@ matrix:
         - php: 7.0
         - php: 7.1
         - php: 7.2
+        - php: 7.3
 
           # Test LTS version we support
-        - php: 7.2
+        - php: 7.3
           env: DEPENDENCIES="symfony/lts:v3"
 
-        - php: 7.2
+        - php: 7.3
           env: DEPENDENCIES="beta"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,4 @@ install:
     - travis_retry composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction
 
 script:
-    - ./vendor/bin/simple-phpunit
+    - ./vendor/bin/phpunit

--- a/Tests/IntegrationTest.php
+++ b/Tests/IntegrationTest.php
@@ -162,9 +162,9 @@ class IntegrationTestKernel extends Kernel
         parent::__construct($environment, $debug);
     }
 
-    public function getName()
+    protected function getContainerClass()
     {
-        return parent::getName().$this->randomKey;
+        return 'test'.$this->randomKey.parent::getContainerClass();
     }
 
     public function registerBundles()

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         }
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^3.3"
+        "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^7.4",
+        "symfony/phpunit-bridge": "^3.4 || ^4.0"
     }
 }


### PR DESCRIPTION
This PR fixes the current build failures:
* Introduce direct dependency to PHPUnit to avoid failures due to 
https://github.com/symfony/symfony/pull/29263
* Fix kernel deprecation as highlighted in #260 
* Add PHP 7.3 to the test matrix (closes #259)