### PR TITLE
Fix fixture loading in non-interactive mode

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -70,7 +70,7 @@ EOT
         $em = $doctrine->getManager($input->getOption('em'));
 
         if (!$input->getOption('append')) {
-            if (!$ui->confirm('Careful, database will be purged. Do you want to continue?', false)) {
+            if (!$ui->confirm('Careful, database will be purged. Do you want to continue?', !$input->isInteractive())) {
                 return;
             }
         }


### PR DESCRIPTION
Fixes #266 (cc @garak). #263 broke running the fixture command when using the `non-interactive` command-line option. This PR ensures that fixtures are always loaded in non-interactive mode while retaining the original behaviour in interactive mode.