### PR TITLE
Fix deprecation on load fixtures command

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -15,8 +15,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use const E_USER_DEPRECATED;
 use function implode;
 use function sprintf;
+use function trigger_error;
 
 /**
  * Load data fixtures from bundles.
@@ -26,9 +28,17 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
     /** @var SymfonyFixturesLoader */
     private $fixturesLoader;
 
-    public function __construct(SymfonyFixturesLoader $fixturesLoader)
+    public function __construct(SymfonyFixturesLoader $fixturesLoader, ?ManagerRegistry $doctrine = null)
     {
-        parent::__construct();
+        if ($doctrine === null) {
+            @trigger_error(sprintf(
+                'The "%s" constructor expects a "%s" instance as second argument, not passing it will throw a \TypeError in DoctrineFixturesBundle 4.0.',
+                static::class,
+                ManagerRegistry::class
+            ), E_USER_DEPRECATED);
+        }
+
+        parent::__construct($doctrine);
 
         $this->fixturesLoader = $fixturesLoader;
     }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,6 +7,7 @@
         <!-- commands -->
         <service id="doctrine.fixtures_load_command" class="Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand">
             <argument type="service" id="doctrine.fixtures.loader" />
+            <argument type="service" id="doctrine" />
             <tag name="console.command" command="doctrine:fixtures:load" />
         </service>
 

--- a/Tests/IntegrationTest.php
+++ b/Tests/IntegrationTest.php
@@ -12,6 +12,7 @@ use Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures\Require
 use Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures\WithDependenciesFixtures;
 use Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\FooBundle;
 use Doctrine\Common\DataFixtures\Loader;
+use Doctrine\Common\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
@@ -348,6 +349,7 @@ class IntegrationTestKernel extends Kernel
     protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader) : void
     {
         $c->setParameter('kernel.secret', 'foo');
+        $c->register('doctrine', ManagerRegistry::class);
         $callback = $this->servicesCallback;
         $callback($c);
     }


### PR DESCRIPTION
```
  1x: The "Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand" constructor expects a "Doctrine\Common\Persistence\ManagerRegistry" instance as first argument, not passing it will throw a \TypeError in DoctrineBundle 2.0.
    1x in Application::run from Symfony\Bundle\FrameworkBundle\Console
  1x: The "Doctrine\Bundle\DoctrineBundle\Command\DoctrineCommand::getContainer()" method is deprecated and will be removed in DoctrineBundle 2.0.
    1x in Application::run from Symfony\Bundle\FrameworkBundle\Console
```