### PR TITLE
Add missing dependency to doctrine/orm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.1.x-dev"
+            "dev-master": "3.2.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "php": "^7.1",
         "doctrine/data-fixtures": "^1.3",
         "doctrine/doctrine-bundle": "^1.6",
+        "doctrine/orm": "^2.6.0",
         "symfony/doctrine-bridge": "~3.4|^4.1",
         "symfony/framework-bundle": "^3.4|^4.1"
     },


### PR DESCRIPTION
This bundle only provides fixture loading for Doctrine ORM, so it should be a hard dependency: installing it without ORM is possible but would lead to errors when running the command, so it makes sense to make this a required dependency.