### PR TITLE
Fix deprecations in fixture command

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use const E_USER_DEPRECATED;
 use function implode;
+use function method_exists;
 use function sprintf;
 use function trigger_error;
 
@@ -38,7 +39,8 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
             ), E_USER_DEPRECATED);
         }
 
-        parent::__construct($doctrine);
+        // @todo The method_exists call can be removed once the DoctrineBundle dependency has been bumped to at least 1.10
+        parent::__construct(method_exists($this, 'getDoctrine') ? $doctrine : null);
 
         $this->fixturesLoader = $fixturesLoader;
     }

--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -85,9 +85,15 @@ EOT
     {
         $ui = new SymfonyStyle($input, $output);
 
-        /** @var ManagerRegistry $doctrine */
-        $doctrine = $this->getContainer()->get('doctrine');
-        $em       = $doctrine->getManager($input->getOption('em'));
+        // @todo The method_exists call can be removed once the DoctrineBundle dependency has been bumped to at least 1.10
+        if (method_exists($this, 'getDotrine')) {
+            $doctrine = $this->getDoctrine();
+        } else {
+            /** @var ManagerRegistry $doctrine */
+            $doctrine = $this->getContainer()->get('doctrine');
+        }
+
+        $em = $doctrine->getManager($input->getOption('em'));
 
         if (! $input->getOption('append')) {
             if (! $ui->confirm(sprintf('Careful, database "%s" will be purged. Do you want to continue?', $em->getConnection()->getDatabase()), ! $input->isInteractive())) {

--- a/Tests/Command/LoadDataFixturesDoctrineCommandTest.php
+++ b/Tests/Command/LoadDataFixturesDoctrineCommandTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\FixturesBundle\Tests\Command;
+
+use Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand;
+use Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+
+class LoadDataFixturesDoctrineCommandTest extends TestCase
+{
+    /**
+     * @group legacy
+     * @expectedDeprecation The "Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand" constructor expects a "Doctrine\Common\Persistence\ManagerRegistry" instance as second argument, not passing it will throw a \TypeError in DoctrineFixturesBundle 4.0.
+     */
+    public function testInstantiatingWithoutManagerRegistry() : void
+    {
+        $loader = new SymfonyFixturesLoader(new Container());
+
+        new LoadDataFixturesDoctrineCommand($loader);
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testInstantiatingWithManagerRegistry() : void
+    {
+        $registry = $this->createMock(ManagerRegistry::class);
+        $loader   = new SymfonyFixturesLoader(new Container());
+
+        new LoadDataFixturesDoctrineCommand($loader, $registry);
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,4 +17,8 @@
             </exclude>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
 </phpunit>


### PR DESCRIPTION
Supersedes #283.

This PR:
* fixes an invalid call to `DoctrineCommand::__construct` on lower DoctrineBundle versions
* removes a call to the deprecated `getContainer()` method if the `getDoctrine()` method is present.

Since this is a bugfix release for 3.2, the dependency to DoctrineBundle can't really be bumped, as it will simply make this bugfix ineligible during version resolution for users of older DoctrineBundle versions. Thus, we work with `method_exists` to ensure the calls are handled correctly, removing this workaround in the next minor release where we'll properly bump the DoctrineBundle dependency.