### PR TITLE
Drop support for older versions of DoctrineBundle

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -17,7 +17,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use const E_USER_DEPRECATED;
 use function implode;
-use function method_exists;
 use function sprintf;
 use function trigger_error;
 
@@ -39,8 +38,7 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
             ), E_USER_DEPRECATED);
         }
 
-        // @todo The method_exists call can be removed once the DoctrineBundle dependency has been bumped to at least 1.10
-        parent::__construct(method_exists($this, 'getDoctrine') ? $doctrine : null);
+        parent::__construct($doctrine);
 
         $this->fixturesLoader = $fixturesLoader;
     }
@@ -85,15 +83,7 @@ EOT
     {
         $ui = new SymfonyStyle($input, $output);
 
-        // @todo The method_exists call can be removed once the DoctrineBundle dependency has been bumped to at least 1.10
-        if (method_exists($this, 'getDotrine')) {
-            $doctrine = $this->getDoctrine();
-        } else {
-            /** @var ManagerRegistry $doctrine */
-            $doctrine = $this->getContainer()->get('doctrine');
-        }
-
-        $em = $doctrine->getManager($input->getOption('em'));
+        $em = $this->getDoctrine()->getManager($input->getOption('em'));
 
         if (! $input->getOption('append')) {
             if (! $ui->confirm(sprintf('Careful, database "%s" will be purged. Do you want to continue?', $em->getConnection()->getDatabase()), ! $input->isInteractive())) {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.1",
         "doctrine/data-fixtures": "^1.3",
-        "doctrine/doctrine-bundle": "^1.6",
+        "doctrine/doctrine-bundle": "^1.11",
         "doctrine/orm": "^2.6.0",
         "symfony/doctrine-bridge": "~3.4|^4.1",
         "symfony/framework-bundle": "^3.4|^4.1"


### PR DESCRIPTION
After #285, we can drop old bundle versions in the next minor release.