### PR TITLE
Allow the exclusion of certain tables when purging

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -71,6 +71,10 @@ If you want to use a TRUNCATE statement instead you can use the <comment>--purge
 
   <info>php %command.full_name%</info> <comment>--purge-with-truncate</comment>
 
+To ignore certain tables from deletion/truncation, use:
+
+  <info>php %command.full_name%</info> <comment>--exclude-table=tablename</comment>
+
 To execute only fixtures that live in a certain group, use:
 
   <info>php %command.full_name%</info> <comment>--group=group1</comment>

--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -54,6 +54,7 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
             ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.')
             ->addOption('purge-with-truncate', null, InputOption::VALUE_NONE, 'Purge data by using a database-level TRUNCATE statement')
+            ->addOption('exclude-table', null, InputOption::VALUE_IS_ARRAY|InputOption::VALUE_OPTIONAL, 'Do not purge the database table with this name')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command loads data fixtures from your application:
 
@@ -104,6 +105,7 @@ EOT
 
         $groups   = $input->getOption('group');
         $fixtures = $this->fixturesLoader->getFixtures($groups);
+        $excluded = $input->getOption('exclude-table');
         if (! $fixtures) {
             $message = 'Could not find any fixture services to load';
 
@@ -115,7 +117,7 @@ EOT
 
             return 1;
         }
-        $purger = new ORMPurger($em);
+        $purger = new ORMPurger($em, $excluded);
         $purger->setPurgeMode($input->getOption('purge-with-truncate') ? ORMPurger::PURGE_MODE_TRUNCATE : ORMPurger::PURGE_MODE_DELETE);
         $executor = new ORMExecutor($em, $purger);
         $executor->setLogger(static function ($message) use ($ui) : void {

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -293,6 +293,20 @@ fixture using the ``UserFixtures`` group:
 
     $ php bin/console doctrine:fixtures:load --group=UserFixtures
 
+Excluding tables: Not purging certain tables
+--------------------------------------------
+
+By default, *all* database tables are purged/truncated. If you want to exclude
+certain tables from this behaviour, you can exclude them with the
+``--exclude-table`` option:
+
+.. code-block:: terminal
+
+    $ php bin/console doctrine:fixtures:load --exclude-table=table1
+
+    # or to exclude multiple tables
+    $ php bin/console doctrine:fixtures:load --exclude-table=table1 --exclude-table=table2
+
 .. _`ORM`: https://symfony.com/doc/current/doctrine.html
 .. _`installation chapter`: https://getcomposer.org/doc/00-intro.md
 .. _`Symfony Flex`: https://symfony.com/doc/current/setup/flex.html


### PR DESCRIPTION
The ORMPurger has a `$excluded` option that allows you to ignore certain tables when purging. The DoctrineFixturesBundle however didn't implement this feature while it does seem very useful [(1)](https://stackoverflow.com/questions/41346893/symfony-doctrine-fixtures-do-not-purge-all-tables).

So I added a `exclude-table` option that allows users to exclude certain tables from purging. I also added the option to the documentation.

Feel free to give feedback if something seems off!