### PR TITLE
Support for custom purgers

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -8,13 +8,15 @@ use Doctrine\Bundle\DoctrineBundle\Command\DoctrineCommand;
 use Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader;
 use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\ManagerRegistry as DeprecatedManagerRegistry;
 use Doctrine\DBAL\Sharding\PoolingShardConnection;
+use Doctrine\Persistence\ManagerRegistry;
 use LogicException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use TypeError;
 use const E_USER_DEPRECATED;
 use function implode;
 use function sprintf;
@@ -28,14 +30,23 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
     /** @var SymfonyFixturesLoader */
     private $fixturesLoader;
 
-    public function __construct(SymfonyFixturesLoader $fixturesLoader, ?ManagerRegistry $doctrine = null)
+    /** @param ManagerRegistry|DeprecatedManagerRegistry|null $doctrine */
+    public function __construct(SymfonyFixturesLoader $fixturesLoader, $doctrine = null)
     {
         if ($doctrine === null) {
             @trigger_error(sprintf(
-                'The "%s" constructor expects a "%s" instance as second argument, not passing it will throw a \TypeError in DoctrineFixturesBundle 4.0.',
-                static::class,
+                'Argument 2 of %s() expects an instance of %s or preferably %s, not passing it will throw a \TypeError in DoctrineFixturesBundle 4.0.',
+                __METHOD__,
+                DeprecatedManagerRegistry::class,
                 ManagerRegistry::class
             ), E_USER_DEPRECATED);
+        } elseif (! $doctrine instanceof ManagerRegistry && ! $doctrine instanceof DeprecatedManagerRegistry) {
+            throw new TypeError(sprintf(
+                'Argument 2 passed to %s() must implement interface %s or preferably %s',
+                __METHOD__,
+                DeprecatedManagerRegistry::class,
+                ManagerRegistry::class
+            ));
         }
 
         parent::__construct($doctrine);

--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\FixturesBundle\Command;
 
 use Doctrine\Bundle\DoctrineBundle\Command\DoctrineCommand;
+use Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\PurgerFactoryCompilerPass;
 use Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader;
+use Doctrine\Bundle\FixturesBundle\Purger\ORMPurgerFactory;
+use Doctrine\Bundle\FixturesBundle\Purger\PurgerFactory;
 use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
-use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\Common\Persistence\ManagerRegistry as DeprecatedManagerRegistry;
 use Doctrine\DBAL\Sharding\PoolingShardConnection;
 use Doctrine\Persistence\ManagerRegistry;
@@ -30,8 +32,14 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
     /** @var SymfonyFixturesLoader */
     private $fixturesLoader;
 
-    /** @param ManagerRegistry|DeprecatedManagerRegistry|null $doctrine */
-    public function __construct(SymfonyFixturesLoader $fixturesLoader, $doctrine = null)
+    /** @var PurgerFactory[] */
+    private $purgerFactories;
+
+    /**
+     * @param ManagerRegistry|DeprecatedManagerRegistry|null $doctrine
+     * @param PurgerFactory[]                                $purgerFactories
+     */
+    public function __construct(SymfonyFixturesLoader $fixturesLoader, $doctrine = null, array $purgerFactories = [])
     {
         if ($doctrine === null) {
             @trigger_error(sprintf(
@@ -51,7 +59,8 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
 
         parent::__construct($doctrine);
 
-        $this->fixturesLoader = $fixturesLoader;
+        $this->fixturesLoader  = $fixturesLoader;
+        $this->purgerFactories = $purgerFactories;
     }
 
     // phpcs:ignore SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
@@ -63,6 +72,8 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
             ->addOption('append', null, InputOption::VALUE_NONE, 'Append the data fixtures instead of deleting all data from the database first.')
             ->addOption('group', null, InputOption::VALUE_IS_ARRAY|InputOption::VALUE_REQUIRED, 'Only load fixtures that belong to this group')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
+            ->addOption('purger', null, InputOption::VALUE_REQUIRED, 'The purger to use for this command', 'default')
+            ->addOption('purge-exclusions', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'List of database tables to ignore while purging')
             ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.')
             ->addOption('purge-with-truncate', null, InputOption::VALUE_NONE, 'Purge data by using a database-level TRUNCATE statement')
             ->setHelp(<<<EOT
@@ -129,8 +140,25 @@ EOT
 
             return 1;
         }
-        $purger = new ORMPurger($em);
-        $purger->setPurgeMode($input->getOption('purge-with-truncate') ? ORMPurger::PURGE_MODE_TRUNCATE : ORMPurger::PURGE_MODE_DELETE);
+
+        if (! isset($this->purgerFactories[$input->getOption('purger')])) {
+            $ui->warning(sprintf(
+                'Could not find purger factory with alias "%1$s", using default purger. Did you forget to register the %2$s implementation with tag "%3$s" and alias "%1$s"?',
+                $input->getOption('purger'),
+                PurgerFactory::class,
+                PurgerFactoryCompilerPass::PURGER_FACTORY_TAG
+            ));
+            $factory = new ORMPurgerFactory();
+        } else {
+            $factory = $this->purgerFactories[$input->getOption('purger')];
+        }
+
+        $purger   = $factory->createForEntityManager(
+            $input->getOption('em'),
+            $em,
+            $input->getOption('purge-exclusions'),
+            $input->getOption('purge-with-truncate')
+        );
         $executor = new ORMExecutor($em, $purger);
         $executor->setLogger(static function ($message) use ($ui) : void {
             $ui->text(sprintf('  <comment>></comment> <info>%s</info>', $message));

--- a/DependencyInjection/CompilerPass/PurgerFactoryCompilerPass.php
+++ b/DependencyInjection/CompilerPass/PurgerFactoryCompilerPass.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass;
+
+use LogicException;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use function sprintf;
+
+final class PurgerFactoryCompilerPass implements CompilerPassInterface
+{
+    public const PURGER_FACTORY_TAG = 'doctrine.fixtures.purger_factory';
+
+    public function process(ContainerBuilder $container) : void
+    {
+        $definition     = $container->getDefinition('doctrine.fixtures_load_command');
+        $taggedServices = $container->findTaggedServiceIds(self::PURGER_FACTORY_TAG);
+
+        $purgerFactories = [];
+        foreach ($taggedServices as $serviceId => $tags) {
+            foreach ($tags as $tagData) {
+                if (! isset($tagData['alias'])) {
+                    throw new LogicException(sprintf('Proxy factory "%s" must define an alias', $serviceId));
+                }
+
+                $purgerFactories[$tagData['alias']] = new Reference($serviceId);
+            }
+        }
+
+        $definition->setArgument(2, $purgerFactories);
+    }
+}

--- a/DoctrineFixturesBundle.php
+++ b/DoctrineFixturesBundle.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\FixturesBundle;
 
 use Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesCompilerPass;
+use Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\PurgerFactoryCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -17,5 +18,6 @@ class DoctrineFixturesBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new FixturesCompilerPass());
+        $container->addCompilerPass(new PurgerFactoryCompilerPass());
     }
 }

--- a/Purger/ORMPurgerFactory.php
+++ b/Purger/ORMPurgerFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\FixturesBundle\Purger;
+
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\Common\DataFixtures\Purger\PurgerInterface;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class ORMPurgerFactory implements PurgerFactory
+{
+    public function createForEntityManager(?string $emName, EntityManagerInterface $em, array $excluded = [], bool $purgeWithTruncate = false) : PurgerInterface
+    {
+        $purger = new ORMPurger($em, $excluded);
+        $purger->setPurgeMode($purgeWithTruncate ? ORMPurger::PURGE_MODE_TRUNCATE : ORMPurger::PURGE_MODE_DELETE);
+
+        return $purger;
+    }
+}

--- a/Purger/PurgerFactory.php
+++ b/Purger/PurgerFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\FixturesBundle\Purger;
+
+use Doctrine\Common\DataFixtures\Purger\PurgerInterface;
+use Doctrine\ORM\EntityManagerInterface;
+
+interface PurgerFactory
+{
+    public function createForEntityManager(?string $emName, EntityManagerInterface $em, array $excluded = [], bool $purgeWithTruncate = false) : PurgerInterface;
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -14,5 +14,9 @@
         <service id="doctrine.fixtures.loader" class="Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader" public="false">
             <argument type="service" id="service_container" />
         </service>
+
+        <service id="doctrine.fixtures.purger.orm_purger_factory" class="Doctrine\Bundle\FixturesBundle\Purger\ORMPurgerFactory" public="false">
+            <tag name="doctrine.fixtures.purger_factory" alias="default"/>
+        </service>
     </services>
 </container>

--- a/Tests/Command/LoadDataFixturesDoctrineCommandTest.php
+++ b/Tests/Command/LoadDataFixturesDoctrineCommandTest.php
@@ -6,16 +6,17 @@ namespace Doctrine\Bundle\FixturesBundle\Tests\Command;
 
 use Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand;
 use Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader;
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Bundle\FixturesBundle\Tests\DeprecationUtil;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use TypeError;
+use function sprintf;
 
 class LoadDataFixturesDoctrineCommandTest extends TestCase
 {
     /**
      * @group legacy
-     * @expectedDeprecation The "Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand" constructor expects a "Doctrine\Common\Persistence\ManagerRegistry" instance as second argument, not passing it will throw a \TypeError in DoctrineFixturesBundle 4.0.
+     * @expectedDeprecation Argument 2 of Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand::__construct() expects an instance of Doctrine\Common\Persistence\ManagerRegistry or preferably Doctrine\Persistence\ManagerRegistry, not passing it will throw a \TypeError in DoctrineFixturesBundle 4.0.
      */
     public function testInstantiatingWithoutManagerRegistry() : void
     {
@@ -24,7 +25,7 @@ class LoadDataFixturesDoctrineCommandTest extends TestCase
         try {
             new LoadDataFixturesDoctrineCommand($loader);
         } catch (TypeError $e) {
-            $this->expectExceptionMessage('Argument 1 passed to Doctrine\Bundle\DoctrineBundle\Command\DoctrineCommand::__construct() must be an instance of Doctrine\Common\Persistence\ManagerRegistry, null given');
+            $this->expectExceptionMessage(sprintf('Argument 1 passed to Doctrine\Bundle\DoctrineBundle\Command\DoctrineCommand::__construct() must be an instance of %s, null given', DeprecationUtil::getManagerRegistryClass()));
 
             throw $e;
         }
@@ -35,7 +36,7 @@ class LoadDataFixturesDoctrineCommandTest extends TestCase
      */
     public function testInstantiatingWithManagerRegistry() : void
     {
-        $registry = $this->createMock(ManagerRegistry::class);
+        $registry = $this->createMock(DeprecationUtil::getManagerRegistryClass());
         $loader   = new SymfonyFixturesLoader(new Container());
 
         new LoadDataFixturesDoctrineCommand($loader, $registry);

--- a/Tests/DeprecationUtil.php
+++ b/Tests/DeprecationUtil.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\FixturesBundle\Tests;
+
+use Doctrine\Common\Persistence\ManagerRegistry as DeprecatedManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
+use function interface_exists;
+
+final class DeprecationUtil
+{
+    public static function getManagerRegistryClass() : string
+    {
+        return interface_exists(ManagerRegistry::class) ? ManagerRegistry::class : DeprecatedManagerRegistry::class;
+    }
+}

--- a/Tests/IntegrationTest.php
+++ b/Tests/IntegrationTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Doctrine\Bundle\FixturesBundle\Tests\IntegrationTest;
+namespace Doctrine\Bundle\FixturesBundle\Tests;
 
 use Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesCompilerPass;
 use Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle;
@@ -12,7 +12,6 @@ use Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures\Require
 use Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures\WithDependenciesFixtures;
 use Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\FooBundle;
 use Doctrine\Common\DataFixtures\Loader;
-use Doctrine\Common\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
@@ -345,7 +344,7 @@ class IntegrationTestKernel extends Kernel
                   ->setPublic(true);
             }
 
-            $c->register('doctrine', ManagerRegistry::class);
+            $c->register('doctrine', DeprecationUtil::getManagerRegistryClass());
 
             $callback = $this->servicesCallback;
             $callback($c);

--- a/Tests/IntegrationTest.php
+++ b/Tests/IntegrationTest.php
@@ -21,8 +21,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 use function array_map;
 use function get_class;
+use function hash;
 use function method_exists;
-use function rand;
+use function spl_object_hash;
 use function sys_get_temp_dir;
 
 class IntegrationTest extends TestCase
@@ -304,6 +305,9 @@ class IntegrationTest extends TestCase
 
 class IntegrationTestKernel extends Kernel
 {
+    /** @var int */
+    private static $invocations = 0;
+
     /** @var callable */
     private $servicesCallback;
 
@@ -312,7 +316,7 @@ class IntegrationTestKernel extends Kernel
 
     public function __construct(string $environment, bool $debug)
     {
-        $this->randomKey = rand(100, 999);
+        $this->randomKey = hash('sha3-384', spl_object_hash($this) . self::$invocations++);
 
         parent::__construct($environment, $debug);
     }

--- a/Tests/Purger/ORMPurgerFactoryTest.php
+++ b/Tests/Purger/ORMPurgerFactoryTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Purger;
+
+use Doctrine\Bundle\FixturesBundle\Purger\ORMPurgerFactory;
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ORMPurgerFactoryTest extends TestCase
+{
+    /** @var ORMPurgerFactory */
+    private $factory;
+
+    /** @var EntityManagerInterface|MockObject */
+    private $em;
+
+    protected function setUp() : void
+    {
+        $this->factory = new ORMPurgerFactory();
+        $this->em      = $this->createMock(EntityManagerInterface::class);
+    }
+
+    public function testCreateDefault() : void
+    {
+        /** @var ORMPurger $purger */
+        $purger = $this->factory->createForEntityManager(null, $this->em);
+
+        self::assertInstanceOf(ORMPurger::class, $purger);
+        self::assertSame(ORMPurger::PURGE_MODE_DELETE, $purger->getPurgeMode());
+        self::assertSame([], (function () {
+            return $this->excluded;
+        })->call($purger));
+    }
+
+    public function testCreateWithExclusions() : void
+    {
+        /** @var ORMPurger $purger */
+        $purger = $this->factory->createForEntityManager(null, $this->em, ['tableName']);
+
+        self::assertInstanceOf(ORMPurger::class, $purger);
+        self::assertSame(ORMPurger::PURGE_MODE_DELETE, $purger->getPurgeMode());
+        self::assertSame(['tableName'], (function () {
+            return $this->excluded;
+        })->call($purger));
+    }
+
+    public function testCreateWithTruncate() : void
+    {
+        /** @var ORMPurger $purger */
+        $purger = $this->factory->createForEntityManager(null, $this->em, [], true);
+
+        self::assertInstanceOf(ORMPurger::class, $purger);
+        self::assertSame(ORMPurger::PURGE_MODE_TRUNCATE, $purger->getPurgeMode());
+        self::assertSame([], (function () {
+            return $this->excluded;
+        })->call($purger));
+    }
+}


### PR DESCRIPTION
This PR allows users to specify a custom purger (as previously requested in #116).

As a user, I can register my custom purger factory, that implements `createForEntityManager(?string $emName, EntityManagerInterface $em, array $excluded = [], bool $purgeWithTruncate = false) : PurgerInterface` with the tag `doctrine.fixtures.purger_factory` and some `alias` and then run the command with `--purger=$alias`. If the `ORMPurger` is used `--purge-exclusions`, a list of tables that ought to not be purged, are supported.