### PR TITLE
$container is no longer available in Fixture class

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -132,10 +132,6 @@ injection::
         $manager->flush();
     }
 
-You can also access the container via the ``$this->container`` property.
-But remember that not *all* services (i.e. private services) can be accessed
-directly via the container.
-
 .. _multiple-files:
 
 Splitting Fixtures into Separate Files


### PR DESCRIPTION
Since ee5eb61, Doctrine\Bundle\FixturesBundle\Fixture does not implement ContainerAwareInterface anymore and thus, $container is not part of this class anymore.

See https://github.com/doctrine/DoctrineFixturesBundle/commit/ee5eb61#diff-8490d6a88059c82df2c98e6f2d0918d2