### PR TITLE
Allow php 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,11 @@ jobs:
           php: 7.3
           env: DEPENDENCIES="dev"
 
+        - stage: test
+          php: nightly
+          before_install:
+              - composer config platform.php 7.4.99
+
         # Run phpcs
         - stage: Code Quality
           php: 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ jobs:
           php: nightly
           before_install:
               - composer config platform.php 7.4.99
+              - composer config minimum-stability dev
 
         # Run phpcs
         - stage: Code Quality

--- a/Tests/Command/LoadDataFixturesDoctrineCommandTest.php
+++ b/Tests/Command/LoadDataFixturesDoctrineCommandTest.php
@@ -10,6 +10,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use TypeError;
+use const PHP_VERSION_ID;
 
 class LoadDataFixturesDoctrineCommandTest extends TestCase
 {
@@ -24,6 +25,14 @@ class LoadDataFixturesDoctrineCommandTest extends TestCase
         try {
             new LoadDataFixturesDoctrineCommand($loader);
         } catch (TypeError $e) {
+            if (PHP_VERSION_ID >= 80000) {
+                $this->expectExceptionMessage(
+                    <<<'MESSAGE'
+Doctrine\Bundle\DoctrineBundle\Command\DoctrineCommand::__construct(): Argument #1 ($doctrine) must be of type Doctrine\Persistence\ManagerRegistry, null given, called in /home/travis/build/doctrine/DoctrineFixturesBundle/Command/LoadDataFixturesDoctrineCommand.php on line 41
+MESSAGE
+                );
+                throw $e;
+            }
             $this->expectExceptionMessage('Argument 1 passed to Doctrine\Bundle\DoctrineBundle\Command\DoctrineCommand::__construct() must be an instance of Doctrine\Persistence\ManagerRegistry, null given');
 
             throw $e;

--- a/Tests/IntegrationTest.php
+++ b/Tests/IntegrationTest.php
@@ -10,6 +10,7 @@ use Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures\OtherFi
 use Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures\RequiredConstructorArgsFixtures;
 use Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures\WithDependenciesFixtures;
 use Doctrine\Common\DataFixtures\Loader;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
@@ -85,10 +86,6 @@ class IntegrationTest extends TestCase
         $this->assertInstanceOf(WithDependenciesFixtures::class, $actualFixtures[1]);
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage The getDependencies() method returned a class (Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures\RequiredConstructorArgsFixtures) that has required constructor arguments. Upgrade to "doctrine/data-fixtures" version 1.3 or higher to support this.
-     */
     public function testExceptionWithDependenciesWithRequiredArguments() : void
     {
         // see https://github.com/doctrine/data-fixtures/pull/274
@@ -112,16 +109,15 @@ class IntegrationTest extends TestCase
         $kernel->boot();
         $container = $kernel->getContainer();
 
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The getDependencies() method returned a class (Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures\RequiredConstructorArgsFixtures) that has required constructor arguments. Upgrade to "doctrine/data-fixtures" version 1.3 or higher to support this.');
+
         /** @var ContainerAwareLoader $loader */
         $loader = $container->get('test.doctrine.fixtures.loader');
 
         $loader->getFixtures();
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage The "Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures\RequiredConstructorArgsFixtures" fixture class is trying to be loaded, but is not available. Make sure this class is defined as a service and tagged with "doctrine.fixture.orm".
-     */
     public function testExceptionIfDependentFixtureNotWired() : void
     {
         // only runs on newer versions of doctrine/data-fixtures
@@ -138,6 +134,9 @@ class IntegrationTest extends TestCase
         });
         $kernel->boot();
         $container = $kernel->getContainer();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The "Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures\RequiredConstructorArgsFixtures" fixture class is trying to be loaded, but is not available. Make sure this class is defined as a service and tagged with "doctrine.fixture.orm".');
 
         /** @var ContainerAwareLoader $loader */
         $loader = $container->get('test.doctrine.fixtures.loader');

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.0",
         "doctrine/data-fixtures": "^1.3",
         "doctrine/doctrine-bundle": "^1.11|^2.0",
         "doctrine/orm": "^2.6.0",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^6.0",
-        "phpunit/phpunit": "^7.4",
+        "phpunit/phpunit": "^7.4 || ^9.2",
         "symfony/phpunit-bridge": "^4.1|^5.0"
     },
     "autoload": {


### PR DESCRIPTION
On pause for now, to be continued when Doctrine dependencies allow php 8