### PR TITLE
Removing internal link

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -74,10 +74,6 @@ Create a fixtures class and start adding products::
         }
     }
 
-.. tip::
-
-    You can also create multiple fixtures classes. See :ref:`multiple-files`.
-
 Loading Fixtures
 ----------------
 


### PR DESCRIPTION
I guess this is the first time that I actually want to *remove* a link :-) But this one leads just one (!) screen down to a self-explanatory heading with the exact same wording. So I would say, it just adds noise.

I you disagree, I'll add the word "below" to signify that it's in fact just a jump link.