### PR TITLE
Bump symfony/dependency-injection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "doctrine/persistence": "^1.3.7|^2.0",
         "symfony/config": "^3.4|^4.3|^5.0",
         "symfony/console": "^3.4|^4.3|^5.0",
-        "symfony/dependency-injection": "^3.4|^4.3|^5.0",
+        "symfony/dependency-injection": "^3.4.47|^4.3|^5.0",
         "symfony/doctrine-bridge": "^3.4|^4.1|^5.0",
         "symfony/http-kernel": "^3.4|^4.3|^5.0"
     },


### PR DESCRIPTION
The --prefer-lowest job fails with an error message that is different
from the 7.1 job, and that seems to be related to dependency injection.