### PR TITLE
Remove workaround for testing with PHP 8

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -66,11 +66,6 @@ jobs:
           coverage: "xdebug"
           ini-values: "zend.assertions=1"
 
-      # to be removed when doctrine/orm adds support for PHP 8
-      - name: "Pretend this is PHP 7.4"
-        run: "composer config platform.php 7.4.99"
-        if: "${{ matrix.php-version == '8.0' }}"
-
       - name: "Use dev stability"
         run: "composer config minimum-stability dev"
         if: "${{ matrix.stability == 'dev' }}"

--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -17,10 +17,12 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use const E_USER_DEPRECATED;
+
 use function implode;
 use function sprintf;
 use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 /**
  * Load data fixtures from bundles.
@@ -52,14 +54,13 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
         $this->purgerFactories = $purgerFactories;
     }
 
-    // phpcs:ignore SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
     protected function configure()
     {
         $this
             ->setName('doctrine:fixtures:load')
             ->setDescription('Load data fixtures to your database')
             ->addOption('append', null, InputOption::VALUE_NONE, 'Append the data fixtures instead of deleting all data from the database first.')
-            ->addOption('group', null, InputOption::VALUE_IS_ARRAY|InputOption::VALUE_REQUIRED, 'Only load fixtures that belong to this group')
+            ->addOption('group', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Only load fixtures that belong to this group')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
             ->addOption('purger', null, InputOption::VALUE_REQUIRED, 'The purger to use for this command', 'default')
             ->addOption('purge-exclusions', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'List of database tables to ignore while purging')
@@ -92,7 +93,6 @@ EOT
     /**
      * @return int
      */
-    // phpcs:ignore SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $ui = new SymfonyStyle($input, $output);
@@ -149,7 +149,7 @@ EOT
             $input->getOption('purge-with-truncate')
         );
         $executor = new ORMExecutor($em, $purger);
-        $executor->setLogger(static function ($message) use ($ui) : void {
+        $executor->setLogger(static function ($message) use ($ui): void {
             $ui->text(sprintf('  <comment>></comment> <info>%s</info>', $message));
         });
         $executor->execute($fixtures, $input->getOption('append'));

--- a/DependencyInjection/CompilerPass/FixturesCompilerPass.php
+++ b/DependencyInjection/CompilerPass/FixturesCompilerPass.php
@@ -12,7 +12,7 @@ final class FixturesCompilerPass implements CompilerPassInterface
 {
     public const FIXTURE_TAG = 'doctrine.fixture.orm';
 
-    public function process(ContainerBuilder $container) : void
+    public function process(ContainerBuilder $container): void
     {
         $definition     = $container->getDefinition('doctrine.fixtures.loader');
         $taggedServices = $container->findTaggedServiceIds(self::FIXTURE_TAG);

--- a/DependencyInjection/CompilerPass/PurgerFactoryCompilerPass.php
+++ b/DependencyInjection/CompilerPass/PurgerFactoryCompilerPass.php
@@ -8,13 +8,14 @@ use LogicException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+
 use function sprintf;
 
 final class PurgerFactoryCompilerPass implements CompilerPassInterface
 {
     public const PURGER_FACTORY_TAG = 'doctrine.fixtures.purger_factory';
 
-    public function process(ContainerBuilder $container) : void
+    public function process(ContainerBuilder $container): void
     {
         $definition     = $container->getDefinition('doctrine.fixtures_load_command');
         $taggedServices = $container->findTaggedServiceIds(self::PURGER_FACTORY_TAG);

--- a/DependencyInjection/DoctrineFixturesExtension.php
+++ b/DependencyInjection/DoctrineFixturesExtension.php
@@ -10,6 +10,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
 use function dirname;
 
 class DoctrineFixturesExtension extends Extension

--- a/DoctrineFixturesBundle.php
+++ b/DoctrineFixturesBundle.php
@@ -9,12 +9,8 @@ use Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\PurgerFactor
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * Bundle.
- */
 class DoctrineFixturesBundle extends Bundle
 {
-    // phpcs:ignore SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new FixturesCompilerPass());

--- a/FixtureGroupInterface.php
+++ b/FixtureGroupInterface.php
@@ -15,5 +15,5 @@ interface FixtureGroupInterface
      *
      * @return string[]
      */
-    public static function getGroups() : array;
+    public static function getGroups(): array;
 }

--- a/Loader/SymfonyFixturesLoader.php
+++ b/Loader/SymfonyFixturesLoader.php
@@ -12,6 +12,7 @@ use LogicException;
 use ReflectionClass;
 use RuntimeException;
 use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
+
 use function array_key_exists;
 use function array_values;
 use function get_class;
@@ -27,8 +28,10 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader
 
     /**
      * @internal
+     *
+     * @psalm-param list<array{fixture: FixtureInterface, groups: list<string>}> $fixtures
      */
-    public function addFixtures(array $fixtures) : void
+    public function addFixtures(array $fixtures): void
     {
         // Because parent::addFixture may call $this->createFixture
         // we cannot call $this->addFixture in this loop
@@ -45,7 +48,7 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader
         }
     }
 
-    public function addFixture(FixtureInterface $fixture) : void
+    public function addFixture(FixtureInterface $fixture): void
     {
         $class                        = get_class($fixture);
         $this->loadedFixtures[$class] = $fixture;
@@ -62,10 +65,9 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader
 
     /**
      * Overridden to not allow new fixture classes to be instantiated.
-     *
-     * @param string $class
+     * {@inheritDoc}
      */
-    protected function createFixture($class) : FixtureInterface
+    protected function createFixture($class): FixtureInterface
     {
         /*
          * We don't actually need to create the fixture. We just
@@ -90,7 +92,7 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader
      *
      * @return FixtureInterface[]
      */
-    public function getFixtures(array $groups = []) : array
+    public function getFixtures(array $groups = []): array
     {
         $fixtures = parent::getFixtures();
 
@@ -121,7 +123,7 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader
      *
      * @param string[] $groups
      */
-    private function addGroupsFixtureMapping(string $className, array $groups) : void
+    private function addGroupsFixtureMapping(string $className, array $groups): void
     {
         foreach ($groups as $group) {
             $this->groupsFixtureMapping[$group][$className] = true;
@@ -133,7 +135,7 @@ final class SymfonyFixturesLoader extends ContainerAwareLoader
      *
      * @throws RuntimeException
      */
-    private function validateDependencies(array $fixtures, FixtureInterface $fixture) : void
+    private function validateDependencies(array $fixtures, FixtureInterface $fixture): void
     {
         if (! $fixture instanceof DependentFixtureInterface) {
             return;

--- a/Purger/ORMPurgerFactory.php
+++ b/Purger/ORMPurgerFactory.php
@@ -10,8 +10,15 @@ use Doctrine\ORM\EntityManagerInterface;
 
 final class ORMPurgerFactory implements PurgerFactory
 {
-    public function createForEntityManager(?string $emName, EntityManagerInterface $em, array $excluded = [], bool $purgeWithTruncate = false) : PurgerInterface
-    {
+    /**
+     * {@inheritDoc}
+     */
+    public function createForEntityManager(
+        ?string $emName,
+        EntityManagerInterface $em,
+        array $excluded = [],
+        bool $purgeWithTruncate = false
+    ): PurgerInterface {
         $purger = new ORMPurger($em, $excluded);
         $purger->setPurgeMode($purgeWithTruncate ? ORMPurger::PURGE_MODE_TRUNCATE : ORMPurger::PURGE_MODE_DELETE);
 

--- a/Purger/PurgerFactory.php
+++ b/Purger/PurgerFactory.php
@@ -9,5 +9,13 @@ use Doctrine\ORM\EntityManagerInterface;
 
 interface PurgerFactory
 {
-    public function createForEntityManager(?string $emName, EntityManagerInterface $em, array $excluded = [], bool $purgeWithTruncate = false) : PurgerInterface;
+    /**
+     * @psalm-param list<string> $excluded
+     */
+    public function createForEntityManager(
+        ?string $emName,
+        EntityManagerInterface $em,
+        array $excluded = [],
+        bool $purgeWithTruncate = false
+    ): PurgerInterface;
 }

--- a/Tests/Command/LoadDataFixturesDoctrineCommandTest.php
+++ b/Tests/Command/LoadDataFixturesDoctrineCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Bundle\FixturesBundle\Tests\Command;
 
+use Doctrine\Bundle\DoctrineBundle\Command\DoctrineCommand;
 use Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand;
 use Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader;
 use Doctrine\Persistence\ManagerRegistry;
@@ -28,18 +29,11 @@ class LoadDataFixturesDoctrineCommandTest extends TestCase
         try {
             new LoadDataFixturesDoctrineCommand($loader);
         } catch (TypeError $e) {
-            if (PHP_VERSION_ID >= 80000) {
-                $this->expectExceptionMessage(
-                    <<<'MESSAGE'
-Doctrine\Bundle\DoctrineBundle\Command\DoctrineCommand::__construct(): Argument #1 ($doctrine) must be of type Doctrine\Persistence\ManagerRegistry, null given, called in /home/runner/work/DoctrineFixturesBundle/DoctrineFixturesBundle/Command/LoadDataFixturesDoctrineCommand.php on line 51
-MESSAGE
-                );
-
-                throw $e;
-            }
-
             $this->expectExceptionMessage(sprintf(
-                'Argument 1 passed to Doctrine\Bundle\DoctrineBundle\Command\DoctrineCommand::__construct() must be an instance of %s, null given',
+                PHP_VERSION_ID >= 80000 ?
+                    '%s::__construct(): Argument #1 ($doctrine) must be of type %s, null given' :
+                    'Argument 1 passed to %s::__construct() must be an instance of %s, null given',
+                DoctrineCommand::class,
                 ManagerRegistry::class
             ));
 

--- a/Tests/Command/LoadDataFixturesDoctrineCommandTest.php
+++ b/Tests/Command/LoadDataFixturesDoctrineCommandTest.php
@@ -10,8 +10,10 @@ use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use TypeError;
-use const PHP_VERSION_ID;
+
 use function sprintf;
+
+use const PHP_VERSION_ID;
 
 class LoadDataFixturesDoctrineCommandTest extends TestCase
 {
@@ -19,7 +21,7 @@ class LoadDataFixturesDoctrineCommandTest extends TestCase
      * @group legacy
      * @expectedDeprecation Argument 2 of Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand::__construct() expects an instance of Doctrine\Persistence\ManagerRegistry, not passing it will throw a \TypeError in DoctrineFixturesBundle 4.0.
      */
-    public function testInstantiatingWithoutManagerRegistry() : void
+    public function testInstantiatingWithoutManagerRegistry(): void
     {
         $loader = new SymfonyFixturesLoader(new Container());
 
@@ -29,11 +31,13 @@ class LoadDataFixturesDoctrineCommandTest extends TestCase
             if (PHP_VERSION_ID >= 80000) {
                 $this->expectExceptionMessage(
                     <<<'MESSAGE'
-Doctrine\Bundle\DoctrineBundle\Command\DoctrineCommand::__construct(): Argument #1 ($doctrine) must be of type Doctrine\Persistence\ManagerRegistry, null given, called in /home/runner/work/DoctrineFixturesBundle/DoctrineFixturesBundle/Command/LoadDataFixturesDoctrineCommand.php on line 49
+Doctrine\Bundle\DoctrineBundle\Command\DoctrineCommand::__construct(): Argument #1 ($doctrine) must be of type Doctrine\Persistence\ManagerRegistry, null given, called in /home/runner/work/DoctrineFixturesBundle/DoctrineFixturesBundle/Command/LoadDataFixturesDoctrineCommand.php on line 51
 MESSAGE
                 );
+
                 throw $e;
             }
+
             $this->expectExceptionMessage(sprintf(
                 'Argument 1 passed to Doctrine\Bundle\DoctrineBundle\Command\DoctrineCommand::__construct() must be an instance of %s, null given',
                 ManagerRegistry::class
@@ -46,7 +50,7 @@ MESSAGE
     /**
      * @doesNotPerformAssertions
      */
-    public function testInstantiatingWithManagerRegistry() : void
+    public function testInstantiatingWithManagerRegistry(): void
     {
         $registry = $this->createMock(ManagerRegistry::class);
         $loader   = new SymfonyFixturesLoader(new Container());

--- a/Tests/Fixtures/FooBundle/DataFixtures/DependentOnRequiredConstructorArgsFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/DependentOnRequiredConstructorArgsFixtures.php
@@ -10,12 +10,15 @@ use Doctrine\Persistence\ObjectManager;
 
 class DependentOnRequiredConstructorArgsFixtures implements ORMFixtureInterface, DependentFixtureInterface
 {
-    public function load(ObjectManager $manager) : void
+    public function load(ObjectManager $manager): void
     {
         // ...
     }
 
-    public function getDependencies() : array
+    /**
+     * {@inheritDoc}
+     */
+    public function getDependencies(): array
     {
         return [RequiredConstructorArgsFixtures::class];
     }

--- a/Tests/Fixtures/FooBundle/DataFixtures/OtherFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/OtherFixtures.php
@@ -10,12 +10,15 @@ use Doctrine\Persistence\ObjectManager;
 
 class OtherFixtures implements ORMFixtureInterface, FixtureGroupInterface
 {
-    public function load(ObjectManager $manager) : void
+    public function load(ObjectManager $manager): void
     {
         // ...
     }
 
-    public static function getGroups() : array
+    /**
+     * {@inheritDoc}
+     */
+    public static function getGroups(): array
     {
         return ['staging', 'fulfilledDependencyGroup'];
     }

--- a/Tests/Fixtures/FooBundle/DataFixtures/RequiredConstructorArgsFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/RequiredConstructorArgsFixtures.php
@@ -13,7 +13,7 @@ class RequiredConstructorArgsFixtures implements ORMFixtureInterface
     {
     }
 
-    public function load(ObjectManager $manager) : void
+    public function load(ObjectManager $manager): void
     {
         // ...
     }

--- a/Tests/Fixtures/FooBundle/DataFixtures/WithDependenciesFixtures.php
+++ b/Tests/Fixtures/FooBundle/DataFixtures/WithDependenciesFixtures.php
@@ -11,17 +11,23 @@ use Doctrine\Persistence\ObjectManager;
 
 class WithDependenciesFixtures implements ORMFixtureInterface, DependentFixtureInterface, FixtureGroupInterface
 {
-    public function load(ObjectManager $manager) : void
+    public function load(ObjectManager $manager): void
     {
         // ...
     }
 
-    public function getDependencies() : array
+    /**
+     * {@inheritDoc}
+     */
+    public function getDependencies(): array
     {
         return [OtherFixtures::class];
     }
 
-    public static function getGroups() : array
+    /**
+     * {@inheritDoc}
+     */
+    public static function getGroups(): array
     {
         return ['missingDependencyGroup', 'fulfilledDependencyGroup'];
     }

--- a/Tests/IntegrationTest.php
+++ b/Tests/IntegrationTest.php
@@ -26,16 +26,18 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+
 use function array_map;
+use function assert;
 use function get_class;
 use function method_exists;
 
 class IntegrationTest extends TestCase
 {
-    public function testFixturesLoader() : void
+    public function testFixturesLoader(): void
     {
         $kernel = new IntegrationTestKernel('dev', true);
-        $kernel->addServices(static function (ContainerBuilder $c) : void {
+        $kernel->addServices(static function (ContainerBuilder $c): void {
             $c->autowire(OtherFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
 
@@ -47,8 +49,8 @@ class IntegrationTest extends TestCase
         $kernel->boot();
         $container = $kernel->getContainer();
 
-        /** @var ContainerAwareLoader $loader */
         $loader = $container->get('test.doctrine.fixtures.loader');
+        assert($loader instanceof ContainerAwareLoader);
 
         $actualFixtures = $loader->getFixtures();
         $this->assertCount(2, $actualFixtures);
@@ -63,12 +65,12 @@ class IntegrationTest extends TestCase
         $this->assertInstanceOf(WithDependenciesFixtures::class, $actualFixtures[1]);
     }
 
-    public function testFixturesLoaderWhenFixtureHasDepdencenyThatIsNotYetLoaded() : void
+    public function testFixturesLoaderWhenFixtureHasDepdencenyThatIsNotYetLoaded(): void
     {
         // See https://github.com/doctrine/DoctrineFixturesBundle/issues/215
 
         $kernel = new IntegrationTestKernel('dev', true);
-        $kernel->addServices(static function (ContainerBuilder $c) : void {
+        $kernel->addServices(static function (ContainerBuilder $c): void {
             $c->autowire(WithDependenciesFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
 
@@ -80,8 +82,8 @@ class IntegrationTest extends TestCase
         $kernel->boot();
         $container = $kernel->getContainer();
 
-        /** @var ContainerAwareLoader $loader */
         $loader = $container->get('test.doctrine.fixtures.loader');
+        assert($loader instanceof ContainerAwareLoader);
 
         $actualFixtures = $loader->getFixtures();
         $this->assertCount(2, $actualFixtures);
@@ -96,7 +98,7 @@ class IntegrationTest extends TestCase
         $this->assertInstanceOf(WithDependenciesFixtures::class, $actualFixtures[1]);
     }
 
-    public function testExceptionWithDependenciesWithRequiredArguments() : void
+    public function testExceptionWithDependenciesWithRequiredArguments(): void
     {
         // see https://github.com/doctrine/data-fixtures/pull/274
         // When that is merged, this test will only run when using
@@ -106,7 +108,7 @@ class IntegrationTest extends TestCase
         }
 
         $kernel = new IntegrationTestKernel('dev', true);
-        $kernel->addServices(static function (ContainerBuilder $c) : void {
+        $kernel->addServices(static function (ContainerBuilder $c): void {
             $c->autowire(DependentOnRequiredConstructorArgsFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
 
@@ -122,13 +124,13 @@ class IntegrationTest extends TestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('The getDependencies() method returned a class (Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures\RequiredConstructorArgsFixtures) that has required constructor arguments. Upgrade to "doctrine/data-fixtures" version 1.3 or higher to support this.');
 
-        /** @var ContainerAwareLoader $loader */
         $loader = $container->get('test.doctrine.fixtures.loader');
+        assert($loader instanceof ContainerAwareLoader);
 
         $loader->getFixtures();
     }
 
-    public function testExceptionIfDependentFixtureNotWired() : void
+    public function testExceptionIfDependentFixtureNotWired(): void
     {
         // only runs on newer versions of doctrine/data-fixtures
         if (! method_exists(Loader::class, 'createFixture')) {
@@ -136,7 +138,7 @@ class IntegrationTest extends TestCase
         }
 
         $kernel = new IntegrationTestKernel('dev', true);
-        $kernel->addServices(static function (ContainerBuilder $c) : void {
+        $kernel->addServices(static function (ContainerBuilder $c): void {
             $c->autowire(DependentOnRequiredConstructorArgsFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
 
@@ -148,16 +150,16 @@ class IntegrationTest extends TestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('The "Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures\RequiredConstructorArgsFixtures" fixture class is trying to be loaded, but is not available. Make sure this class is defined as a service and tagged with "doctrine.fixture.orm".');
 
-        /** @var ContainerAwareLoader $loader */
         $loader = $container->get('test.doctrine.fixtures.loader');
+        assert($loader instanceof ContainerAwareLoader);
 
         $loader->getFixtures();
     }
 
-    public function testFixturesLoaderWithGroupsOptionViaInterface() : void
+    public function testFixturesLoaderWithGroupsOptionViaInterface(): void
     {
         $kernel = new IntegrationTestKernel('dev', true);
-        $kernel->addServices(static function (ContainerBuilder $c) : void {
+        $kernel->addServices(static function (ContainerBuilder $c): void {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
               ->addTag(FixturesCompilerPass::FIXTURE_TAG);
@@ -171,8 +173,8 @@ class IntegrationTest extends TestCase
         $kernel->boot();
         $container = $kernel->getContainer();
 
-        /** @var ContainerAwareLoader $loader */
         $loader = $container->get('test.doctrine.fixtures.loader');
+        assert($loader instanceof ContainerAwareLoader);
 
         $actualFixtures = $loader->getFixtures(['staging']);
         $this->assertCount(1, $actualFixtures);
@@ -186,10 +188,10 @@ class IntegrationTest extends TestCase
         $this->assertInstanceOf(OtherFixtures::class, $actualFixtures[0]);
     }
 
-    public function testFixturesLoaderWithGroupsOptionViaTag() : void
+    public function testFixturesLoaderWithGroupsOptionViaTag(): void
     {
         $kernel = new IntegrationTestKernel('dev', true);
-        $kernel->addServices(static function (ContainerBuilder $c) : void {
+        $kernel->addServices(static function (ContainerBuilder $c): void {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG, ['group' => 'group1'])
@@ -204,8 +206,8 @@ class IntegrationTest extends TestCase
         $kernel->boot();
         $container = $kernel->getContainer();
 
-        /** @var ContainerAwareLoader $loader */
         $loader = $container->get('test.doctrine.fixtures.loader');
+        assert($loader instanceof ContainerAwareLoader);
 
         $this->assertCount(1, $loader->getFixtures(['staging']));
         $this->assertCount(1, $loader->getFixtures(['group1']));
@@ -213,10 +215,10 @@ class IntegrationTest extends TestCase
         $this->assertCount(0, $loader->getFixtures(['group3']));
     }
 
-    public function testLoadFixturesViaGroupWithMissingDependency() : void
+    public function testLoadFixturesViaGroupWithMissingDependency(): void
     {
         $kernel = new IntegrationTestKernel('dev', true);
-        $kernel->addServices(static function (ContainerBuilder $c) : void {
+        $kernel->addServices(static function (ContainerBuilder $c): void {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
@@ -230,8 +232,8 @@ class IntegrationTest extends TestCase
         $kernel->boot();
         $container = $kernel->getContainer();
 
-        /** @var ContainerAwareLoader $loader */
         $loader = $container->get('test.doctrine.fixtures.loader');
+        assert($loader instanceof ContainerAwareLoader);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Fixture "Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures\OtherFixtures" was declared as a dependency for fixture "Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures\WithDependenciesFixtures", but it was not included in any of the loaded fixture groups.');
@@ -239,10 +241,10 @@ class IntegrationTest extends TestCase
         $loader->getFixtures(['missingDependencyGroup']);
     }
 
-    public function testLoadFixturesViaGroupWithFulfilledDependency() : void
+    public function testLoadFixturesViaGroupWithFulfilledDependency(): void
     {
         $kernel = new IntegrationTestKernel('dev', true);
-        $kernel->addServices(static function (ContainerBuilder $c) : void {
+        $kernel->addServices(static function (ContainerBuilder $c): void {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
@@ -256,8 +258,8 @@ class IntegrationTest extends TestCase
         $kernel->boot();
         $container = $kernel->getContainer();
 
-        /** @var ContainerAwareLoader $loader */
         $loader = $container->get('test.doctrine.fixtures.loader');
+        assert($loader instanceof ContainerAwareLoader);
 
         $actualFixtures = $loader->getFixtures(['fulfilledDependencyGroup']);
 
@@ -272,10 +274,10 @@ class IntegrationTest extends TestCase
         ], $actualFixtureClasses);
     }
 
-    public function testLoadFixturesByShortName() : void
+    public function testLoadFixturesByShortName(): void
     {
         $kernel = new IntegrationTestKernel('dev', true);
-        $kernel->addServices(static function (ContainerBuilder $c) : void {
+        $kernel->addServices(static function (ContainerBuilder $c): void {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
@@ -289,8 +291,8 @@ class IntegrationTest extends TestCase
         $kernel->boot();
         $container = $kernel->getContainer();
 
-        /** @var ContainerAwareLoader $loader */
         $loader = $container->get('test.doctrine.fixtures.loader');
+        assert($loader instanceof ContainerAwareLoader);
 
         $actualFixtures = $loader->getFixtures(['OtherFixtures']);
 
@@ -304,10 +306,10 @@ class IntegrationTest extends TestCase
         ], $actualFixtureClasses);
     }
 
-    public function testRunCommandWithDefaultPurger() : void
+    public function testRunCommandWithDefaultPurger(): void
     {
         $kernel = new IntegrationTestKernel('dev', true);
-        $kernel->addServices(static function (ContainerBuilder $c) : void {
+        $kernel->addServices(static function (ContainerBuilder $c): void {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
@@ -345,16 +347,16 @@ class IntegrationTest extends TestCase
             ->willReturn($purger);
         $container->set('test.doctrine.fixtures.purger.orm_purger_factory', $purgerFactory);
 
-        /** @var LoadDataFixturesDoctrineCommand $command */
         $command = $container->get('test.doctrine.fixtures_load_command');
-        $tester  = new CommandTester($command);
+        assert($command instanceof LoadDataFixturesDoctrineCommand);
+        $tester = new CommandTester($command);
         $tester->execute([], ['interactive' => false]);
     }
 
-    public function testRunCommandWithPurgeExclusions() : void
+    public function testRunCommandWithPurgeExclusions(): void
     {
         $kernel = new IntegrationTestKernel('dev', true);
-        $kernel->addServices(static function (ContainerBuilder $c) : void {
+        $kernel->addServices(static function (ContainerBuilder $c): void {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
@@ -392,16 +394,16 @@ class IntegrationTest extends TestCase
             ->willReturn($purger);
         $container->set('test.doctrine.fixtures.purger.orm_purger_factory', $purgerFactory);
 
-        /** @var LoadDataFixturesDoctrineCommand $command */
         $command = $container->get('test.doctrine.fixtures_load_command');
-        $tester  = new CommandTester($command);
+        assert($command instanceof LoadDataFixturesDoctrineCommand);
+        $tester = new CommandTester($command);
         $tester->execute(['--purge-exclusions' => ['excluded_table']], ['interactive' => false]);
     }
 
-    public function testRunCommandWithCustomPurgerAndCustomEntityManager() : void
+    public function testRunCommandWithCustomPurgerAndCustomEntityManager(): void
     {
         $kernel = new IntegrationTestKernel('dev', true);
-        $kernel->addServices(static function (ContainerBuilder $c) : void {
+        $kernel->addServices(static function (ContainerBuilder $c): void {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
@@ -442,16 +444,16 @@ class IntegrationTest extends TestCase
             ->willReturn($purger);
         $container->set('test.doctrine.fixtures.purger.test_factory', $purgerFactory);
 
-        /** @var LoadDataFixturesDoctrineCommand $command */
         $command = $container->get('test.doctrine.fixtures_load_command');
-        $tester  = new CommandTester($command);
+        assert($command instanceof LoadDataFixturesDoctrineCommand);
+        $tester = new CommandTester($command);
         $tester->execute(['--purger' => 'test', '--em' => 'alternative'], ['interactive' => false]);
     }
 
-    public function testRunCommandWithPurgeMode() : void
+    public function testRunCommandWithPurgeMode(): void
     {
         $kernel = new IntegrationTestKernel('dev', true);
-        $kernel->addServices(static function (ContainerBuilder $c) : void {
+        $kernel->addServices(static function (ContainerBuilder $c): void {
             // has a "staging" group via the getGroups() method
             $c->autowire(OtherFixtures::class)
                 ->addTag(FixturesCompilerPass::FIXTURE_TAG);
@@ -489,9 +491,9 @@ class IntegrationTest extends TestCase
             ->willReturn($purger);
         $container->set('test.doctrine.fixtures.purger.orm_purger_factory', $purgerFactory);
 
-        /** @var LoadDataFixturesDoctrineCommand $command */
         $command = $container->get('test.doctrine.fixtures_load_command');
-        $tester  = new CommandTester($command);
+        assert($command instanceof LoadDataFixturesDoctrineCommand);
+        $tester = new CommandTester($command);
         $tester->execute(['--purge-with-truncate' => true], ['interactive' => false]);
     }
 }

--- a/Tests/IntegrationTestKernel.php
+++ b/Tests/IntegrationTestKernel.php
@@ -10,6 +10,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
+
 use function rand;
 use function sys_get_temp_dir;
 
@@ -28,12 +29,15 @@ class IntegrationTestKernel extends Kernel
         parent::__construct($environment, $debug);
     }
 
-    protected function getContainerClass() : string
+    protected function getContainerClass(): string
     {
         return 'test' . $this->randomKey . parent::getContainerClass();
     }
 
-    public function registerBundles() : array
+    /**
+     * {@inheritDoc}
+     */
+    public function registerBundles(): array
     {
         return [
             new DoctrineFixturesBundle(),
@@ -41,14 +45,14 @@ class IntegrationTestKernel extends Kernel
         ];
     }
 
-    public function addServices(callable $callback) : void
+    public function addServices(callable $callback): void
     {
         $this->servicesCallback = $callback;
     }
 
-    public function registerContainerConfiguration(LoaderInterface $loader) : void
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
-        $loader->load(function (ContainerBuilder $c) : void {
+        $loader->load(function (ContainerBuilder $c): void {
             if (! $c->hasDefinition('kernel')) {
                 $c->register('kernel', static::class)
                   ->setSynthetic(true)
@@ -64,12 +68,12 @@ class IntegrationTestKernel extends Kernel
         });
     }
 
-    public function getCacheDir() : string
+    public function getCacheDir(): string
     {
         return sys_get_temp_dir() . '/doctrine_fixtures_bundle' . $this->randomKey;
     }
 
-    public function getLogDir() : string
+    public function getLogDir(): string
     {
         return sys_get_temp_dir();
     }

--- a/Tests/Purger/ORMPurgerFactoryTest.php
+++ b/Tests/Purger/ORMPurgerFactoryTest.php
@@ -10,6 +10,8 @@ use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+use function assert;
+
 class ORMPurgerFactoryTest extends TestCase
 {
     /** @var ORMPurgerFactory */
@@ -18,16 +20,16 @@ class ORMPurgerFactoryTest extends TestCase
     /** @var EntityManagerInterface|MockObject */
     private $em;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->factory = new ORMPurgerFactory();
         $this->em      = $this->createMock(EntityManagerInterface::class);
     }
 
-    public function testCreateDefault() : void
+    public function testCreateDefault(): void
     {
-        /** @var ORMPurger $purger */
         $purger = $this->factory->createForEntityManager(null, $this->em);
+        assert($purger instanceof ORMPurger);
 
         self::assertInstanceOf(ORMPurger::class, $purger);
         self::assertSame(ORMPurger::PURGE_MODE_DELETE, $purger->getPurgeMode());
@@ -36,10 +38,10 @@ class ORMPurgerFactoryTest extends TestCase
         })->call($purger));
     }
 
-    public function testCreateWithExclusions() : void
+    public function testCreateWithExclusions(): void
     {
-        /** @var ORMPurger $purger */
         $purger = $this->factory->createForEntityManager(null, $this->em, ['tableName']);
+        assert($purger instanceof ORMPurger);
 
         self::assertInstanceOf(ORMPurger::class, $purger);
         self::assertSame(ORMPurger::PURGE_MODE_DELETE, $purger->getPurgeMode());
@@ -48,10 +50,10 @@ class ORMPurgerFactoryTest extends TestCase
         })->call($purger));
     }
 
-    public function testCreateWithTruncate() : void
+    public function testCreateWithTruncate(): void
     {
-        /** @var ORMPurger $purger */
         $purger = $this->factory->createForEntityManager(null, $this->em, [], true);
+        assert($purger instanceof ORMPurger);
 
         self::assertInstanceOf(ORMPurger::class, $purger);
         self::assertSame(ORMPurger::PURGE_MODE_TRUNCATE, $purger->getPurgeMode());

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/http-kernel": "^3.4|^4.3|^5.0"
     },
     "require-dev": {
-        "doctrine/coding-standard": "^6.0",
+        "doctrine/coding-standard": "^8.0",
         "phpunit/phpunit": "^7.4 || ^8.0 || ^9.2",
         "symfony/phpunit-bridge": "^4.1|^5.0"
     },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,6 +6,8 @@
     <arg name="cache" value=".phpcs-cache"/>
     <arg name="colors"/>
 
+    <config name="php_version" value="70100"/>
+
      <!-- Ignore warnings and show progress of the run -->
     <arg value="np"/>
 
@@ -13,18 +15,14 @@
     <exclude-pattern>/vendor</exclude-pattern>
 
     <rule ref="Doctrine">
-        <!-- Traversable type hints often end up as mixed[], so we skip them for now -->
-        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversablePropertyTypeHintSpecification"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableParameterTypeHintSpecification"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableReturnTypeHintSpecification"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint"/>
     </rule>
+
 
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming.SuperfluousSuffix">
         <exclude-pattern>FixtureGroupInterface.php</exclude-pattern>
         <exclude-pattern>ORMFixtureInterface.php</exclude-pattern>
-    </rule>
-    <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint">
-        <exclude-pattern>Loader/SymfonyFixturesLoader.php</exclude-pattern>
     </rule>
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude-pattern>Tests/IntegrationTest.php</exclude-pattern>


### PR DESCRIPTION
Now that all dependencies support it, it should not be necessary to
pretend we are using PHP 7.4. Implies upgrading the CS lib.