### PR TITLE
Symfony v4 bundle fix

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -42,8 +42,7 @@ update the ``AppKernel`` class::
         $bundles[] = new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle();
     }
     
-You will also need to enable the bundle. In Symfony 5.2.7 or higher applications,
-update the ``bundles.php`` 
+In Symfony 4 or higher, you need to update ``bundles.php`` instead.
 
     // config/bundles.php
 

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -49,7 +49,7 @@ In Symfony 4 or higher, you need to update ``bundles.php`` instead.
     // ...
     //in the  add  this line array  
     return [...,
-    Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
+        Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
     ]
     
     

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -47,7 +47,6 @@ In Symfony 4 or higher, you need to update ``bundles.php`` instead.
     // config/bundles.php
 
     // ...
-    //in the  add  this line array  
     return [...,
         Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
     ]

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -41,7 +41,20 @@ update the ``AppKernel`` class::
         // ...
         $bundles[] = new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle();
     }
+    
+You will also need to enable the bundle. In Symfony 5.2.7 or higher applications,
+update the ``bundles.php`` 
 
+    // config/bundles.php
+
+    // ...
+    //in the  add  this line array  
+    return [...,
+    Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
+    ]
+    
+    
+   
 Writing Fixtures
 ----------------
 


### PR DESCRIPTION
in Symfony  v5.2.7   bundle will be in the file config/bundles.php  not in app/AppKernel.php