### PR TITLE
Fixing database "name" (=path) for SQLite

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -103,7 +103,13 @@ EOT
         assert($em instanceof EntityManagerInterface);
 
         if (! $input->getOption('append')) {
-            if (! $ui->confirm(sprintf('Careful, database "%s" will be purged. Do you want to continue?', $em->getConnection()->getDatabase()), ! $input->isInteractive())) {
+            if ('sqlite' === $em->getConnection()->getDatabasePlatform()->getName()) {
+                $params = $em->getConnection()->getParams();
+                $database = $params['path'];
+            } else {
+                $database = $em->getConnection()->getDatabase();
+            }
+            if (! $ui->confirm(sprintf('Careful, database "%s" will be purged. Do you want to continue?', $database), ! $input->isInteractive())) {
                 return 0;
             }
         }


### PR DESCRIPTION
Since DBAL 3.0 (see https://github.com/doctrine/migrations/pull/1028), the message currently reads for SQLite:
> Careful, database "" will be purged. Do you want to continue? (yes/no)

Neither @Ocramius (see https://github.com/doctrine/dbal/pull/3606#discussion_r292713610) nor me (see https://github.com/doctrine/dbal/pull/4982) succeeded in convincing @morozov to continue returning the file path ;-) So it looks like the fix needs to be done here...

Suggestion: What about adding the platform too? So the message would be:
> Careful, **MySQL** database "foo" will be purged. Do you want to continue? (yes/no)

BTW: `doctrine/migrations` is currently broken too:

> WARNING! You are about to execute a migration in database "<unnamed>" that could result in schema changes and data loss. Are you sure you wish to continue? (yes/no) [yes]:

So when done here, I'm going to submit the same there  (i.e. follow up of https://github.com/doctrine/migrations/pull/1028)