### PR TITLE
Documenting how fixtures can be moved from /src/DataFixures to a custom directory

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -420,7 +420,7 @@ Then, enable Dependency Injection for the ``fixtures`` directory:
 
 .. caution::
 
-    This will not override the default ``/src/DataFixtures`` directory when creating fixtures with the
+    This will not override the default ``src/DataFixtures`` directory when creating fixtures with the
     `Symfony MakerBundle` (``make:fixtures``).
 
 .. _`Symfony MakerBundle`: https://symfony.com/bundles/SymfonyMakerBundle/current/index.html

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -384,3 +384,43 @@ With the ``--purger`` option we can now specify to use ``my_purger`` instead of 
 
 .. _`Doctrine ORM`: https://symfony.com/doc/current/doctrine.html
 .. _`DoctrineMongoDBBundle`: https://github.com/doctrine/DoctrineMongoDBBundle
+
+
+How to load Fixtures from a different Directoy
+---------------------------
+By default, fixtures are loaded from the ``/src/DataFixtures``-directory.
+In this example, we are going to load our DataFixtures from a new ``/fixtures`` directory.
+
+First, add a new ``PSR-4`` autoload-entry in the ``composer.json`` with the new ``/fixtures`` directory:
+
+.. code-block:: json
+
+    "autoload-dev": {
+        "psr-4": {
+            "...": "...",
+            "DataFixtures\\": "fixtures"
+        }
+    },
+
+Then, enable Dependency Injection for the ``/fixtures`` directory:
+
+.. code-block:: php
+
+    // config/services.php
+    namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+    return function(ContainerConfigurator $configurator) : void {
+        $services = $container->services()
+            ->defaults()
+                ->autowire()
+                ->autoconfigure();
+
+        $services->load('DataFixtures\\', '../fixtures');
+    };
+
+.. caution::
+
+    This will not override the default ``/src/DataFixtures`` directory when creating fixtures with the
+    `Symfony MakerBundle` (``make:fixtures``).
+
+.. _`Symfony MakerBundle`: https://symfony.com/bundles/SymfonyMakerBundle/current/index.html

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -402,7 +402,7 @@ First, add a new ``PSR-4`` autoload-entry in the ``composer.json`` with the new 
         }
     },
 
-Then, enable Dependency Injection for the ``/fixtures`` directory:
+Then, enable Dependency Injection for the ``fixtures`` directory:
 
 .. code-block:: php
 

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -389,7 +389,7 @@ With the ``--purger`` option we can now specify to use ``my_purger`` instead of 
 How to load Fixtures from a different Directory
 -----------------------------------------------
 By default, fixtures are loaded from the ``src/DataFixtures`` directory.
-In this example, we are going to load our DataFixtures from a new ``/fixtures`` directory.
+In this example, we are going to load our DataFixtures from a new ``fixtures`` directory.
 
 First, add a new ``PSR-4`` autoload-entry in the ``composer.json`` with the new ``/fixtures`` directory:
 

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -409,7 +409,7 @@ Then, enable Dependency Injection for the ``/fixtures`` directory:
     // config/services.php
     namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-    return function(ContainerConfigurator $configurator) : void {
+    return function(ContainerConfigurator $container) : void {
         $services = $container->services()
             ->defaults()
                 ->autowire()

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -386,8 +386,8 @@ With the ``--purger`` option we can now specify to use ``my_purger`` instead of 
 .. _`DoctrineMongoDBBundle`: https://github.com/doctrine/DoctrineMongoDBBundle
 
 
-How to load Fixtures from a different Directoy
----------------------------
+How to load Fixtures from a different Directory
+-----------------------------------------------
 By default, fixtures are loaded from the ``/src/DataFixtures``-directory.
 In this example, we are going to load our DataFixtures from a new ``/fixtures`` directory.
 

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -391,7 +391,7 @@ How to load Fixtures from a different Directory
 By default, fixtures are loaded from the ``src/DataFixtures`` directory.
 In this example, we are going to load our DataFixtures from a new ``fixtures`` directory.
 
-First, add a new ``PSR-4`` autoload-entry in the ``composer.json`` with the new ``/fixtures`` directory:
+First, add a new ``PSR-4`` autoload-entry in the ``composer.json`` with the new ``fixtures`` directory:
 
 .. code-block:: json
 

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -388,7 +388,7 @@ With the ``--purger`` option we can now specify to use ``my_purger`` instead of 
 
 How to load Fixtures from a different Directory
 -----------------------------------------------
-By default, fixtures are loaded from the ``/src/DataFixtures``-directory.
+By default, fixtures are loaded from the ``src/DataFixtures`` directory.
 In this example, we are going to load our DataFixtures from a new ``/fixtures`` directory.
 
 First, add a new ``PSR-4`` autoload-entry in the ``composer.json`` with the new ``/fixtures`` directory:


### PR DESCRIPTION
Doctrine fixtures can be loaded from any directory/file (https://www.doctrine-project.org/projects/doctrine-data-fixtures/en/latest/how-to/loading-fixtures.html#loading-fixtures). 

But it is not clear on how to do this with the DoctrineBundle:

1. "How to Override Symfony's default Directory Structure"
    - https://symfony.com/doc/current/configuration/override_dir_structure.html
    - No word of fixtures

2. "How to Override any Part of a Bundle"
    - https://symfony.com/doc/current/bundles/override.html
    - No mentions of directories/fixtures

3. "DoctrineFixturesBundle" (this repository)
    - https://symfony.com/bundles/DoctrineFixturesBundle/current/index.html
    - No option/configuration mentioned to customize the "DataFixtures"-directory.