### PR TITLE
chore: add ci tests for php 8.2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,6 +29,7 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
         dependencies:
           - "highest"
         stability:
@@ -46,11 +47,11 @@ jobs:
             php-version: "7.3"
           - dependencies: "highest"
             stability: "dev"
-            php-version: "8.1"
+            php-version: "8.2"
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
         with:
           fetch-depth: 2
 
@@ -113,7 +114,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
         with:
           fetch-depth: 2
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,4 +13,4 @@ jobs:
   static-analysis:
     uses: "doctrine/.github/.github/workflows/static-analysis.yml@1.4.1"
     with:
-      php-version: "8.1"
+      php-version: "8.2"

--- a/Tests/IntegrationTestKernel.php
+++ b/Tests/IntegrationTestKernel.php
@@ -25,7 +25,7 @@ class IntegrationTestKernel extends Kernel
 
     public function __construct(string $environment, bool $debug)
     {
-        $this->randomKey = rand(100, 999);
+        $this->randomKey = rand(10000000000, 99999999999);
 
         parent::__construct($environment, $debug);
     }


### PR DESCRIPTION
bump github action version for checkout 2 => 3

The failing test is not related to php 8.2.
If i run tests locally with php 8.2 (and php 8.1) i get different results after each run.
range is from 0 to 3 errors.

`Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException : You have requested a non-existent service "test.doctrine.fixtures.loader". Did you mean this: "test.doctrine.fixtures_load_command"?`