### PR TITLE
 add "void" as a native return type declaration

### DIFF
--- a/DoctrineFixturesBundle.php
+++ b/DoctrineFixturesBundle.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class DoctrineFixturesBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new FixturesCompilerPass());
         $container->addCompilerPass(new PurgerFactoryCompilerPass());


### PR DESCRIPTION
> !!  2023-04-08T19:35:15+00:00 [info] User Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. Do the same in child class "Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle" now to avoid errors or add an explicit @return annotation to suppress this message.