### PR TITLE
Add `return void` annotation to silence deprecation msg

### DIFF
--- a/DependencyInjection/DoctrineFixturesExtension.php
+++ b/DependencyInjection/DoctrineFixturesExtension.php
@@ -17,6 +17,8 @@ class DoctrineFixturesExtension extends Extension
 {
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function load(array $configs, ContainerBuilder $container)
     {

--- a/DoctrineFixturesBundle.php
+++ b/DoctrineFixturesBundle.php
@@ -11,6 +11,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class DoctrineFixturesBundle extends Bundle
 {
+    /** @return void */
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new FixturesCompilerPass());

--- a/Tests/IntegrationTestKernel.php
+++ b/Tests/IntegrationTestKernel.php
@@ -79,6 +79,7 @@ class IntegrationTestKernel extends Kernel
         return sys_get_temp_dir();
     }
 
+    /** @return void */
     protected function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new class implements CompilerPassInterface {


### PR DESCRIPTION
> can you please send a PR to add the `@return void` annotation? That's enough to express the intent and fix the deprecation.

ref https://github.com/doctrine/DoctrineFixturesBundle/pull/381#issuecomment-1502825960

Used single/one line annotation syntax as [proposed elsewhere](https://github.com/doctrine/DoctrineMigrationsBundle/pull/492#discussion_r1150441505) 

//cc @nicolas-grekas 