### PR TITLE
Added `return void` annotation to suppress deprecation warnings in Command::configure()

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -56,6 +56,7 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
         $this->purgerFactories = $purgerFactories;
     }
 
+    /** @return void */
     protected function configure()
     {
         $this


### PR DESCRIPTION
When version 3.4.3 of this bundle is used together with Symfony 6.3 (Symfony 6.3.0-BETA1), the following warning is logged:

```
Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand" now to avoid errors or add an explicit @return annotation to suppress this message.
```