### PR TITLE
Add code example for purge exclusion

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -302,7 +302,11 @@ By default all previously existing data is purged using ``DELETE FROM table`` st
 
 If you want to exclude a set of tables from being purged, e.g. because your schema comes with pre-populated,
 semi-static data, pass the option ``--purge-exclusions``. Specify ``--purge-exclusions`` multiple times to exclude
-multiple tables.
+multiple tables:
+
+.. code-block:: terminal
+
+    $ php bin/console doctrine:fixtures:load --exclude-table=post_category --exclude-table=comment_type
 
 You can also customize purging behavior significantly more and implement a custom purger plus a custom purger factory::
 

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -306,7 +306,7 @@ multiple tables:
 
 .. code-block:: terminal
 
-    $ php bin/console doctrine:fixtures:load --exclude-table=post_category --exclude-table=comment_type
+    $ php bin/console doctrine:fixtures:load --purge-exclusions=post_category --purge-exclusions=comment_type
 
 You can also customize purging behavior significantly more and implement a custom purger plus a custom purger factory::
 


### PR DESCRIPTION
There is a section talking about excluding tables from the fixtures purge but no example, making it hard to see this feature exists. This commit adds an example for this command option.