### PR TITLE
[Doc] Fix a minor doc syntax issue

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -429,6 +429,6 @@ Then, enable Dependency Injection for the ``fixtures`` directory:
 .. caution::
 
     This will not override the default ``src/DataFixtures`` directory when creating fixtures with the
-    `Symfony MakerBundle` (``make:fixtures``).
+    `Symfony MakerBundle`_ (``make:fixtures``).
 
 .. _`Symfony MakerBundle`: https://symfony.com/bundles/SymfonyMakerBundle/current/index.html


### PR DESCRIPTION
Without this, the text is not displayed as a link.