### PR TITLE
Allow symfony 7 dependencies

### DIFF
--- a/Loader/SymfonyFixturesLoader.php
+++ b/Loader/SymfonyFixturesLoader.php
@@ -8,17 +8,17 @@ use Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesComp
 use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Common\DataFixtures\Loader;
 use LogicException;
 use ReflectionClass;
 use RuntimeException;
-use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
 
 use function array_key_exists;
 use function array_values;
 use function get_class;
 use function sprintf;
 
-final class SymfonyFixturesLoader extends ContainerAwareLoader
+final class SymfonyFixturesLoader extends Loader
 {
     /** @var FixtureInterface[] */
     private $loadedFixtures = [];

--- a/Tests/Command/LoadDataFixturesDoctrineCommandTest.php
+++ b/Tests/Command/LoadDataFixturesDoctrineCommandTest.php
@@ -9,7 +9,6 @@ use Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand;
 use Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\DependencyInjection\Container;
 use TypeError;
 
 use function sprintf;
@@ -24,7 +23,7 @@ class LoadDataFixturesDoctrineCommandTest extends TestCase
      */
     public function testInstantiatingWithoutManagerRegistry(): void
     {
-        $loader = new SymfonyFixturesLoader(new Container());
+        $loader = new SymfonyFixturesLoader();
 
         try {
             new LoadDataFixturesDoctrineCommand($loader);
@@ -47,7 +46,7 @@ class LoadDataFixturesDoctrineCommandTest extends TestCase
     public function testInstantiatingWithManagerRegistry(): void
     {
         $registry = $this->createMock(ManagerRegistry::class);
-        $loader   = new SymfonyFixturesLoader(new Container());
+        $loader   = new SymfonyFixturesLoader();
 
         new LoadDataFixturesDoctrineCommand($loader, $registry);
     }

--- a/Tests/IntegrationTest.php
+++ b/Tests/IntegrationTest.php
@@ -22,7 +22,6 @@ use Doctrine\Persistence\ManagerRegistry;
 use LogicException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -51,7 +50,7 @@ class IntegrationTest extends TestCase
         $container = $kernel->getContainer();
 
         $loader = $container->get('test.doctrine.fixtures.loader');
-        assert($loader instanceof ContainerAwareLoader);
+        assert($loader instanceof Loader);
 
         $actualFixtures = $loader->getFixtures();
         $this->assertCount(2, $actualFixtures);
@@ -84,7 +83,7 @@ class IntegrationTest extends TestCase
         $container = $kernel->getContainer();
 
         $loader = $container->get('test.doctrine.fixtures.loader');
-        assert($loader instanceof ContainerAwareLoader);
+        assert($loader instanceof Loader);
 
         $actualFixtures = $loader->getFixtures();
         $this->assertCount(2, $actualFixtures);
@@ -123,7 +122,7 @@ class IntegrationTest extends TestCase
         $container = $kernel->getContainer();
 
         $loader = $container->get('test.doctrine.fixtures.loader');
-        assert($loader instanceof ContainerAwareLoader);
+        assert($loader instanceof Loader);
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('The getDependencies() method returned a class (Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures\RequiredConstructorArgsFixtures) that has required constructor arguments. Upgrade to "doctrine/data-fixtures" version 1.3 or higher to support this.');

--- a/Tests/IntegrationTestKernel.php
+++ b/Tests/IntegrationTestKernel.php
@@ -79,8 +79,7 @@ class IntegrationTestKernel extends Kernel
         return sys_get_temp_dir();
     }
 
-    /** @return void */
-    protected function build(ContainerBuilder $container)
+    protected function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new class implements CompilerPassInterface {
             public function process(ContainerBuilder $container): void

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,11 @@
         "doctrine/doctrine-bundle": "^1.11|^2.0",
         "doctrine/orm": "^2.6.0",
         "doctrine/persistence": "^1.3.7|^2.0|^3.0",
-        "symfony/config": "^3.4|^4.3|^5.0|^6.0",
-        "symfony/console": "^3.4|^4.3|^5.0|^6.0",
-        "symfony/dependency-injection": "^3.4.47|^4.3|^5.0|^6.0",
-        "symfony/doctrine-bridge": "^3.4|^4.1|^5.0|^6.0",
-        "symfony/http-kernel": "^3.4|^4.3|^5.0|^6.0"
+        "symfony/config": "^3.4|^4.3|^5.0|^6.0|^7.0",
+        "symfony/console": "^3.4|^4.3|^5.0|^6.0|^7.0",
+        "symfony/dependency-injection": "^3.4.47|^4.3|^5.0|^6.0|^7.0",
+        "symfony/doctrine-bridge": "^3.4|^4.1|^5.0|^6.0|^7.0",
+        "symfony/http-kernel": "^3.4|^4.3|^5.0|^6.0|^7.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^9",


### PR DESCRIPTION
Hi!

Allowing Symfony 7 dependencies to be installed.

This requires a BC break: to stop using the deprecated [ContainerAwareLoader](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Bridge/Doctrine/DataFixtures/ContainerAwareLoader.php).

Do we want to TRY to have a BC-layer? It would require, I think, some config where the user "turns off" the `ContainerAwareLoader` to silence the deprecation. Honestly, I don't think anyone has used container-aware loaders for a long time - requiring an option sounds annoying for users. I'd vote for a new 4.0 with this change, but I'll defer to what others think is best.

If we did a new major, we could also very easily drop old php & Symfony versions.

Cheers!