### PR TITLE
Adding int return type in command

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -93,10 +93,7 @@ EOT
         );
     }
 
-    /**
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $ui = new SymfonyStyle($input, $output);
 


### PR DESCRIPTION
Seen while trying to upgrade a Symfony app to Symfony 7.0.

```
PHP Fatal error: 
Declaration of Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand::execute
(InputInterface $input, OutputInterface $output)
must be compatible with Symfony\Component\Console\Command\Command::execute
(InputInterface $input, OutputInterface $output): int
in vendor/doctrine/doctrine-fixtures-bundle/Command/LoadDataFixturesDoctrineCommand.php on line 99
```