### PR TITLE
add return types to LoadDataFixturesDoctrineCommand.php

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -57,7 +57,7 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
     }
 
     /** @return void */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('doctrine:fixtures:load')
@@ -96,7 +96,7 @@ EOT
     /**
      * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $ui = new SymfonyStyle($input, $output);
 


### PR DESCRIPTION
Fixes #399

Is 4.x the right branch?  I expected this file to have #[AsCommand()] at the top instead of ->setName(), so maybe I'm on the wrong branch.  Is there another branch that support Symfony 7?