### PR TITLE
Add a return type in LoadDataFixturesDoctrineCommand

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -93,10 +93,7 @@ EOT
         );
     }
 
-    /**
-     * @return int
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $ui = new SymfonyStyle($input, $output);
 


### PR DESCRIPTION
Without this change, you see the following error when using this in a Symfony 7 app:

```
PHP Fatal error:  Declaration of

Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand::
execute(InputInterface $input, OutputInterface $output)

must be compatible with Symfony\Component\Console\Command\Command::
execute(InputInterface $input, OutputInterface $output): int

in vendor/doctrine/doctrine-fixtures-bundle/Command/LoadDataFixturesDoctrineCommand.php on line 99
```