### PR TITLE
Drop support for Symfony 3 + 4

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,9 +23,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
-          - "7.2"
-          - "7.3"
           - "7.4"
           - "8.0"
           - "8.1"
@@ -35,17 +32,9 @@ jobs:
           - "highest"
         stability:
           - "stable"
-        extra_constraint:
-          - ""
         include:
           - dependencies: "lowest"
-            php-version: "7.1"
-          - dependencies: "highest"
-            extra_constraint: "symfony/lts:v3"
-            php-version: "7.3"
-          - dependencies: "highest"
-            stability: "dev"
-            php-version: "7.3"
+            php-version: "7.4"
           - dependencies: "highest"
             stability: "dev"
             php-version: "8.3"
@@ -58,27 +47,14 @@ jobs:
 
       - name: "Install PHP with PCOV"
         uses: "shivammathur/setup-php@v2"
-        if: "${{ matrix.php-version != '7.1' }}"
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: "pcov"
           ini-values: "zend.assertions=1"
 
-      - name: "Install PHP with XDebug"
-        uses: "shivammathur/setup-php@v2"
-        if: "${{ matrix.php-version == '7.1' }}"
-        with:
-          php-version: "${{ matrix.php-version }}"
-          coverage: "xdebug"
-          ini-values: "zend.assertions=1"
-
       - name: "Use dev stability"
         run: "composer config minimum-stability dev"
         if: "${{ matrix.stability == 'dev' }}"
-
-      - name: "Add extra constraint"
-        run: "composer require --no-update ${{matrix.extra_constraint}}"
-        if: "${{ contains(matrix.extra_constraint, '/') }}"
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v2"

--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -22,9 +22,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use function assert;
 use function implode;
 use function sprintf;
-use function trigger_error;
-
-use const E_USER_DEPRECATED;
+use function trigger_deprecation;
 
 /**
  * Load data fixtures from bundles.
@@ -33,21 +31,22 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
 {
     use CommandCompatibility;
 
-    /** @var SymfonyFixturesLoader */
-    private $fixturesLoader;
+    private SymfonyFixturesLoader $fixturesLoader;
 
     /** @var PurgerFactory[] */
-    private $purgerFactories;
+    private array $purgerFactories;
 
     /** @param PurgerFactory[] $purgerFactories */
     public function __construct(SymfonyFixturesLoader $fixturesLoader, ?ManagerRegistry $doctrine = null, array $purgerFactories = [])
     {
         if ($doctrine === null) {
-            @trigger_error(sprintf(
+            trigger_deprecation(
+                'doctrine/fixtures-bundle',
+                '3.2',
                 'Argument 2 of %s() expects an instance of %s, not passing it will throw a \TypeError in DoctrineFixturesBundle 4.0.',
                 __METHOD__,
-                ManagerRegistry::class
-            ), E_USER_DEPRECATED);
+                ManagerRegistry::class,
+            );
         }
 
         parent::__construct($doctrine);

--- a/Loader/SymfonyFixturesLoader.php
+++ b/Loader/SymfonyFixturesLoader.php
@@ -20,10 +20,10 @@ use function sprintf;
 final class SymfonyFixturesLoader extends SymfonyBridgeLoader
 {
     /** @var FixtureInterface[] */
-    private $loadedFixtures = [];
+    private array $loadedFixtures = [];
 
     /** @var array<string, array<string, bool>> */
-    private $groupsFixtureMapping = [];
+    private array $groupsFixtureMapping = [];
 
     /**
      * @internal

--- a/Tests/Command/LoadDataFixturesDoctrineCommandTest.php
+++ b/Tests/Command/LoadDataFixturesDoctrineCommandTest.php
@@ -9,6 +9,7 @@ use Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand;
 use Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\Container;
 use TypeError;
 
@@ -18,13 +19,14 @@ use const PHP_VERSION_ID;
 
 class LoadDataFixturesDoctrineCommandTest extends TestCase
 {
-    /**
-     * @group legacy
-     * @expectedDeprecation Argument 2 of Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand::__construct() expects an instance of Doctrine\Persistence\ManagerRegistry, not passing it will throw a \TypeError in DoctrineFixturesBundle 4.0.
-     */
+    use ExpectDeprecationTrait;
+
+    /** @group legacy */
     public function testInstantiatingWithoutManagerRegistry(): void
     {
         $loader = new SymfonyFixturesLoader(new Container());
+
+        $this->expectDeprecation('Since doctrine/fixtures-bundle 3.2: Argument 2 of Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand::__construct() expects an instance of Doctrine\Persistence\ManagerRegistry, not passing it will throw a \TypeError in DoctrineFixturesBundle 4.0.');
 
         try {
             new LoadDataFixturesDoctrineCommand($loader);

--- a/Tests/IntegrationTestKernel.php
+++ b/Tests/IntegrationTestKernel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Bundle\FixturesBundle\Tests;
 
+use Closure;
 use Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle;
 use Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\FooBundle;
 use Doctrine\Persistence\ManagerRegistry;
@@ -17,11 +18,8 @@ use function sys_get_temp_dir;
 
 class IntegrationTestKernel extends Kernel
 {
-    /** @var callable */
-    private $servicesCallback;
-
-    /** @var int */
-    private $randomKey;
+    private ?Closure $servicesCallback = null;
+    private int $randomKey;
 
     public function __construct(string $environment, bool $debug)
     {
@@ -46,7 +44,7 @@ class IntegrationTestKernel extends Kernel
         ];
     }
 
-    public function addServices(callable $callback): void
+    public function addServices(Closure $callback): void
     {
         $this->servicesCallback = $callback;
     }

--- a/Tests/Purger/ORMPurgerFactoryTest.php
+++ b/Tests/Purger/ORMPurgerFactoryTest.php
@@ -14,11 +14,10 @@ use function assert;
 
 class ORMPurgerFactoryTest extends TestCase
 {
-    /** @var ORMPurgerFactory */
-    private $factory;
+    private ORMPurgerFactory $factory;
 
-    /** @var EntityManagerInterface|MockObject */
-    private $em;
+    /** @var EntityManagerInterface&MockObject */
+    private EntityManagerInterface $em;
 
     protected function setUp(): void
     {

--- a/composer.json
+++ b/composer.json
@@ -20,23 +20,24 @@
         }
     ],
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "doctrine/data-fixtures": "^1.3",
-        "doctrine/doctrine-bundle": "^1.11|^2.0",
-        "doctrine/orm": "^2.6.0",
-        "doctrine/persistence": "^1.3.7|^2.0|^3.0",
-        "symfony/config": "^3.4|^4.3|^5.0|^6.0|^7.0",
-        "symfony/console": "^3.4|^4.3|^5.0|^6.0|^7.0",
-        "symfony/dependency-injection": "^3.4.47|^4.3|^5.0|^6.0|^7.0",
-        "symfony/doctrine-bridge": "^3.4|^4.1|^5.0|^6.0|^7.0",
-        "symfony/http-kernel": "^3.4|^4.3|^5.0|^6.0|^7."
+        "doctrine/doctrine-bundle": "^2.2",
+        "doctrine/orm": "^2.14.0",
+        "doctrine/persistence": "^2.4|^3.0",
+        "symfony/config": "^5.4|^6.0|^7.0",
+        "symfony/console": "^5.4|^6.0|^7.0",
+        "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+        "symfony/deprecation-contracts": "^2.1|^3",
+        "symfony/doctrine-bridge": "^5.4|^6.0|^7.0",
+        "symfony/http-kernel": "^5.4|^6.0|^7.0"
     },
     "require-dev": {
-        "doctrine/coding-standard": "^9 || ^12",
-        "phpstan/phpstan": "^1.4.10",
-        "phpunit/phpunit": "^7.5.20 || ^8.5.26 || ^9.5.20",
-        "symfony/phpunit-bridge": "^6.3",
-        "vimeo/psalm": "^4.22"
+        "doctrine/coding-standard": "^12",
+        "phpstan/phpstan": "^1.10.39",
+        "phpunit/phpunit": "^9.6.13",
+        "symfony/phpunit-bridge": "^6.3.6",
+        "vimeo/psalm": "^4.30"
     },
     "autoload": {
         "psr-4": { "Doctrine\\Bundle\\FixturesBundle\\": "" }


### PR DESCRIPTION
This PR drops the support for PHP 7.1 - 7.3 and Symfony 3 - 5.3. We've done the same on the data fixtures repo with doctrine/data-fixtures#438 and I believe it only makes sense to keep the requirements of the bundle in sync with the library it's supposed to integrate.