### PR TITLE
Fixes missing Symfony 7 (BETA3) type-hint for the Command to load the fixtures

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -54,8 +54,7 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
         $this->purgerFactories = $purgerFactories;
     }
 
-    /** @return void */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('doctrine:fixtures:load')
@@ -91,8 +90,7 @@ EOT
         );
     }
 
-    /** @return int */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $ui = new SymfonyStyle($input, $output);
 


### PR DESCRIPTION
The source code in branch 4.0.x does not match with the Symfony 7 type-hint requirements to use the bundle's command.

This PR sets them to make sure this bundle is compatible with the framework.