### PR TITLE
Drop support for DBAL 2

### DIFF
--- a/Command/LoadDataFixturesDoctrineCommand.php
+++ b/Command/LoadDataFixturesDoctrineCommand.php
@@ -10,10 +10,8 @@ use Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader;
 use Doctrine\Bundle\FixturesBundle\Purger\ORMPurgerFactory;
 use Doctrine\Bundle\FixturesBundle\Purger\PurgerFactory;
 use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
-use Doctrine\DBAL\Sharding\PoolingShardConnection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
-use LogicException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -66,7 +64,6 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
             ->addOption('purger', null, InputOption::VALUE_REQUIRED, 'The purger to use for this command', 'default')
             ->addOption('purge-exclusions', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'List of database tables to ignore while purging')
-            ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.')
             ->addOption('purge-with-truncate', null, InputOption::VALUE_NONE, 'Purge data by using a database-level TRUNCATE statement')
             ->setHelp(<<<'EOT'
 The <info>%command.name%</info> command loads data fixtures from your application:
@@ -103,17 +100,6 @@ EOT
             if (! $ui->confirm(sprintf('Careful, database "%s" will be purged. Do you want to continue?', $em->getConnection()->getDatabase()), ! $input->isInteractive())) {
                 return 0;
             }
-        }
-
-        if ($input->getOption('shard')) {
-            if (! $em->getConnection() instanceof PoolingShardConnection) {
-                throw new LogicException(sprintf(
-                    'Connection of EntityManager "%s" must implement shards configuration.',
-                    $input->getOption('em')
-                ));
-            }
-
-            $em->getConnection()->connect($input->getOption('shard'));
         }
 
         $groups   = $input->getOption('group');

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,9 @@
         "symfony/phpunit-bridge": "^6.3.6",
         "vimeo/psalm": "^4.30"
     },
+    "conflict": {
+        "doctrine/dbal": "< 3"
+    },
     "autoload": {
         "psr-4": { "Doctrine\\Bundle\\FixturesBundle\\": "" }
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,16 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Call to method connect\\(\\) on an unknown class Doctrine\\\\DBAL\\\\Sharding\\\\PoolingShardConnection\\.$#"
-			count: 1
-			path: Command/LoadDataFixturesDoctrineCommand.php
-
-		-
-			message: "#^Class Doctrine\\\\DBAL\\\\Sharding\\\\PoolingShardConnection not found\\.$#"
-			count: 1
-			path: Command/LoadDataFixturesDoctrineCommand.php
-
-		-
 			message: "#^Constructor of class Doctrine\\\\Bundle\\\\FixturesBundle\\\\Tests\\\\Fixtures\\\\FooBundle\\\\DataFixtures\\\\RequiredConstructorArgsFixtures has an unused parameter \\$fooRequiredArg\\.$#"
 			count: 1
 			path: Tests/Fixtures/FooBundle/DataFixtures/RequiredConstructorArgsFixtures.php


### PR DESCRIPTION
The `shard` option can only be used if DBAL 2 is installed. Given that nobody should still be using DBAL 2 anymore, let's remove the option.