### PR TITLE
Automatically extract fixture dependencies

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5,6 +5,11 @@ parameters:
 
 	ignoreErrors:
 		-
+			message: "#^Call to an undefined method Doctrine\\\\Bundle\\\\FixturesBundle\\\\Loader\\\\SymfonyFixturesLoader\\:\\:getFixture\\(\\)\\.$#"
+			count: 1
+			path: src/Loader/SymfonyFixturesLoader.php
+
+		-
 			message: "#^Call to an undefined static method Doctrine\\\\Bundle\\\\FixturesBundle\\\\Loader\\\\SymfonyBridgeLoader\\:\\:addFixture\\(\\)\\.$#"
 			count: 1
 			path: src/Loader/SymfonyFixturesLoader.php

--- a/src/Loader/SymfonyFixturesLoader.php
+++ b/src/Loader/SymfonyFixturesLoader.php
@@ -10,9 +10,8 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\DataFixtures\FixtureInterface;
 use LogicException;
 use ReflectionClass;
-use RuntimeException;
 
-use function array_key_exists;
+use function array_keys;
 use function array_values;
 use function get_class;
 use function sprintf;
@@ -99,19 +98,22 @@ final class SymfonyFixturesLoader extends SymfonyBridgeLoader
             return $fixtures;
         }
 
-        $filteredFixtures = [];
-        foreach ($fixtures as $fixture) {
-            foreach ($groups as $group) {
-                $fixtureClass = get_class($fixture);
-                if (isset($this->groupsFixtureMapping[$group][$fixtureClass])) {
-                    $filteredFixtures[$fixtureClass] = $fixture;
-                    continue 2;
-                }
+        $requiredFixtures = [];
+        foreach ($groups as $group) {
+            if (! isset($this->groupsFixtureMapping[$group])) {
+                continue;
             }
+
+            $requiredFixtures += $this->collectDependencies(...array_keys($this->groupsFixtureMapping[$group]));
         }
 
-        foreach ($filteredFixtures as $fixture) {
-            $this->validateDependencies($filteredFixtures, $fixture);
+        $filteredFixtures = [];
+        foreach ($fixtures as $order => $fixture) {
+            $fixtureClass = get_class($fixture);
+            if (isset($requiredFixtures[$fixtureClass])) {
+                $filteredFixtures[$order] = $fixture;
+                continue;
+            }
         }
 
         return array_values($filteredFixtures);
@@ -130,22 +132,25 @@ final class SymfonyFixturesLoader extends SymfonyBridgeLoader
     }
 
     /**
-     * @param string[] $fixtures An array of fixtures with class names as keys
+     * Collect any dependent fixtures from the given classes.
      *
-     * @throws RuntimeException
+     * @psalm-return array<string,true>
      */
-    private function validateDependencies(array $fixtures, FixtureInterface $fixture): void
+    private function collectDependencies(string ...$fixtureClass): array
     {
-        if (! $fixture instanceof DependentFixtureInterface) {
-            return;
-        }
+        $dependencies = [];
 
-        $dependenciesClasses = $fixture->getDependencies();
+        foreach ($fixtureClass as $class) {
+            $dependencies[$class] = true;
+            $fixture              = $this->getFixture($class);
 
-        foreach ($dependenciesClasses as $class) {
-            if (! array_key_exists($class, $fixtures)) {
-                throw new RuntimeException(sprintf('Fixture "%s" was declared as a dependency for fixture "%s", but it was not included in any of the loaded fixture groups.', $class, get_class($fixture)));
+            if (! $fixture instanceof DependentFixtureInterface) {
+                continue;
             }
+
+            $dependencies += $this->collectDependencies(...$fixture->getDependencies());
         }
+
+        return $dependencies;
     }
 }

--- a/tests/Fixtures/FooBundle/DataFixtures/WithDeepDependenciesFixtures.php
+++ b/tests/Fixtures/FooBundle/DataFixtures/WithDeepDependenciesFixtures.php
@@ -9,7 +9,7 @@ use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-class WithDependenciesFixtures implements ORMFixtureInterface, DependentFixtureInterface, FixtureGroupInterface
+class WithDeepDependenciesFixtures implements ORMFixtureInterface, DependentFixtureInterface, FixtureGroupInterface
 {
     public function load(ObjectManager $manager): void
     {
@@ -21,7 +21,7 @@ class WithDependenciesFixtures implements ORMFixtureInterface, DependentFixtureI
      */
     public function getDependencies(): array
     {
-        return [OtherFixtures::class];
+        return [WithDependenciesFixtures::class, DependentOnRequiredConstructorArgsFixtures::class];
     }
 
     /**
@@ -29,6 +29,6 @@ class WithDependenciesFixtures implements ORMFixtureInterface, DependentFixtureI
      */
     public static function getGroups(): array
     {
-        return ['groupWithDependencies', 'fulfilledDependencyGroup'];
+        return ['groupWithDeepDependencies'];
     }
 }


### PR DESCRIPTION
Fixes https://github.com/doctrine/DoctrineFixturesBundle/issues/371

This improves the cooperation between the native fixture dependencies and the bundle provided groups. It is now no longer necessary to add the dependencies of fixtures in a group into the group as well.

I've not tested this extensively, or added tests for this yet but if the maintainers are happy with the change in behaviour I can do that.