### PR TITLE
Dismiss new PHPStan issues

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,5 +1,24 @@
 parameters:
+	excludePaths:
+		# Contains an error that is impossible to ignore
+		- Tests/IntegrationTest.php
+
 	ignoreErrors:
+		-
+			message: "#^Call to an undefined static method Doctrine\\\\Bundle\\\\FixturesBundle\\\\Loader\\\\SymfonyBridgeLoader\\:\\:addFixture\\(\\)\\.$#"
+			count: 1
+			path: Loader/SymfonyFixturesLoader.php
+
+		-
+			message: "#^Call to an undefined static method Doctrine\\\\Bundle\\\\FixturesBundle\\\\Loader\\\\SymfonyBridgeLoader\\:\\:getFixtures\\(\\)\\.$#"
+			count: 1
+			path: Loader/SymfonyFixturesLoader.php
+
+		-
+			message: "#^Class Doctrine\\\\Bundle\\\\FixturesBundle\\\\Loader\\\\SymfonyFixturesLoader does not have a constructor and must be instantiated without any parameters\\.$#"
+			count: 2
+			path: Tests/Command/LoadDataFixturesDoctrineCommandTest.php
+
 		-
 			message: "#^Constructor of class Doctrine\\\\Bundle\\\\FixturesBundle\\\\Tests\\\\Fixtures\\\\FooBundle\\\\DataFixtures\\\\RequiredConstructorArgsFixtures has an unused parameter \\$fooRequiredArg\\.$#"
 			count: 1


### PR DESCRIPTION
Running the latest PHPStan produces this output:

```
------ --------------------------------------------------------------------------------------------------------------
 Line   Loader/SymfonyFixturesLoader.php
------ --------------------------------------------------------------------------------------------------------------
 62     Call to an undefined static method Doctrine\Bundle\FixturesBundle\Loader\SymfonyBridgeLoader::addFixture().
 96     Call to an undefined static method Doctrine\Bundle\FixturesBundle\Loader\SymfonyBridgeLoader::getFixtures().
------ --------------------------------------------------------------------------------------------------------------

------ ------------------------------------------------------------------------------------------------------------------------------------------------
 Line   Tests/Command/LoadDataFixturesDoctrineCommandTest.php
------ ------------------------------------------------------------------------------------------------------------------------------------------------
 27     Class Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader does not have a constructor and must be instantiated without any parameters.
 50     Class Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader does not have a constructor and must be instantiated without any parameters.
------ ------------------------------------------------------------------------------------------------------------------------------------------------

------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Line   Tests/IntegrationTest.php
------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 467    Return type mixed of method Doctrine\Bundle\FixturesBundle\Tests\ForwardCompatibleEntityManager::wrapInTransaction() is not covariant with return type mixed of method Doctrine\ORM\EntityManagerInterface::wrapInTransaction().
------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

All of them happen in the context of compatibility layers. The last one cannot be ignored for some reason.