### PR TITLE
Address deprecation of HttpKernel Extension class

### DIFF
--- a/src/DependencyInjection/DoctrineFixturesExtension.php
+++ b/src/DependencyInjection/DoctrineFixturesExtension.php
@@ -8,8 +8,8 @@ use Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesComp
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 use function dirname;
 


### PR DESCRIPTION
The right class to use now is in the DI component, which does make a lot more sense.