### PR TITLE
Update Symfony bundle metadata

### DIFF
--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -8,5 +8,5 @@ maintained_branches:
     - "3.5.x"
     - "3.6.x"
     - "3.7.x"
-doc_dir: "docs/"
+doc_dir: {"3.5.x": "Resources/doc/", "3.6.x": "docs/", "3.7.x": "docs/"}
 dev_branch: "3.7.x"

--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -5,8 +5,7 @@ branches:
     - "3.6.x"
     - "3.7.x"
 maintained_branches:
-    - "3.5.x"
     - "3.6.x"
     - "3.7.x"
-doc_dir: {"3.5.x": "Resources/doc/", "3.6.x": "docs/", "3.7.x": "docs/"}
+doc_dir: "docs/"
 dev_branch: "3.7.x"


### PR DESCRIPTION
The building of the docs of 3.5.x branch started failing on symfony.com. We need to update this config because 3.5.x stores the docs in a different path.