### PR TITLE
Fix deprecations and ensure compatibility with Symfony 6.4 (#420) for…

### DIFF
--- a/config/services.xml
+++ b/config/services.xml
@@ -12,7 +12,8 @@
         </service>
 
         <service id="doctrine.fixtures.loader" class="Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader" public="false">
-            <argument type="service" id="service_container" />
+            <argument>%doctrine_fixtures.use_container_aware_loader%</argument>
+            <argument type="service" id="service_container" on-invalid="null" />
         </service>
 
         <service id="doctrine.fixtures.purger.orm_purger_factory" class="Doctrine\Bundle\FixturesBundle\Purger\ORMPurgerFactory" public="false">

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5,26 +5,6 @@ parameters:
 
 	ignoreErrors:
 		-
-			message: "#^Call to an undefined method Doctrine\\\\Bundle\\\\FixturesBundle\\\\Loader\\\\SymfonyFixturesLoader\\:\\:getFixture\\(\\)\\.$#"
-			count: 1
-			path: src/Loader/SymfonyFixturesLoader.php
-
-		-
-			message: "#^Call to an undefined static method Doctrine\\\\Bundle\\\\FixturesBundle\\\\Loader\\\\SymfonyBridgeLoader\\:\\:addFixture\\(\\)\\.$#"
-			count: 1
-			path: src/Loader/SymfonyFixturesLoader.php
-
-		-
-			message: "#^Call to an undefined static method Doctrine\\\\Bundle\\\\FixturesBundle\\\\Loader\\\\SymfonyBridgeLoader\\:\\:getFixtures\\(\\)\\.$#"
-			count: 1
-			path: src/Loader/SymfonyFixturesLoader.php
-
-		-
-			message: "#^Class Doctrine\\\\Bundle\\\\FixturesBundle\\\\Loader\\\\SymfonyFixturesLoader does not have a constructor and must be instantiated without any parameters\\.$#"
-			count: 2
-			path: tests/Command/LoadDataFixturesDoctrineCommandTest.php
-
-		-
 			message: "#^Constructor of class Doctrine\\\\Bundle\\\\FixturesBundle\\\\Tests\\\\Fixtures\\\\FooBundle\\\\DataFixtures\\\\RequiredConstructorArgsFixtures has an unused parameter \\$fooRequiredArg\\.$#"
 			count: 1
 			path: tests/Fixtures/FooBundle/DataFixtures/RequiredConstructorArgsFixtures.php

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Doctrine\Bundle\FixturesBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('doctrine_fixtures');
+
+        $rootNode = $treeBuilder->getRootNode();
+        $rootNode
+            ->children()
+            ->booleanNode('use_container_aware_loader')
+            ->defaultTrue()
+            ->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Bundle\FixturesBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -12,12 +15,13 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder('doctrine_fixtures');
 
         $rootNode = $treeBuilder->getRootNode();
-        $rootNode
-            ->children()
-            ->booleanNode('use_container_aware_loader')
-            ->defaultTrue()
-            ->end()
-            ->end();
+
+        if ($rootNode instanceof ArrayNodeDefinition) {
+            $rootNode->children()
+                ->booleanNode('use_container_aware_loader')
+                ->defaultTrue()
+                ->end();
+        }
 
         return $treeBuilder;
     }

--- a/src/DependencyInjection/DoctrineFixturesExtension.php
+++ b/src/DependencyInjection/DoctrineFixturesExtension.php
@@ -10,8 +10,8 @@ use Exception;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 use function dirname;
 
@@ -21,6 +21,7 @@ class DoctrineFixturesExtension extends Extension
      * {@inheritDoc}
      *
      * @return void
+     *
      * @throws Exception
      */
     public function load(array $configs, ContainerBuilder $container): void
@@ -30,7 +31,7 @@ class DoctrineFixturesExtension extends Extension
         $loader->load('services.xml');
 
         $configuration = $this->getConfiguration($configs, $container);
-        $config = $this->processConfiguration($configuration, $configs);
+        $config        = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('doctrine_fixtures.use_container_aware_loader', $config['use_container_aware_loader']);
 
@@ -38,6 +39,13 @@ class DoctrineFixturesExtension extends Extension
             ->addTag(FixturesCompilerPass::FIXTURE_TAG);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @param array $config
+     *
+     * @return ConfigurationInterface|null
+     */
     public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigurationInterface
     {
         return new Configuration();

--- a/src/DependencyInjection/DoctrineFixturesExtension.php
+++ b/src/DependencyInjection/DoctrineFixturesExtension.php
@@ -6,10 +6,12 @@ namespace Doctrine\Bundle\FixturesBundle\DependencyInjection;
 
 use Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesCompilerPass;
 use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
+use Exception;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 use function dirname;
 
@@ -19,14 +21,25 @@ class DoctrineFixturesExtension extends Extension
      * {@inheritDoc}
      *
      * @return void
+     * @throws Exception
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new XmlFileLoader($container, new FileLocator(dirname(__DIR__) . '/../config'));
 
         $loader->load('services.xml');
 
+        $configuration = $this->getConfiguration($configs, $container);
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $container->setParameter('doctrine_fixtures.use_container_aware_loader', $config['use_container_aware_loader']);
+
         $container->registerForAutoconfiguration(ORMFixtureInterface::class)
             ->addTag(FixturesCompilerPass::FIXTURE_TAG);
+    }
+
+    public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigurationInterface
+    {
+        return new Configuration();
     }
 }

--- a/src/Loader/SymfonyBridgeLoader.php
+++ b/src/Loader/SymfonyBridgeLoader.php
@@ -5,18 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\FixturesBundle\Loader;
 
 use Doctrine\Common\DataFixtures\Loader;
-use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
 
-use function class_exists;
-
-if (class_exists(ContainerAwareLoader::class)) {
-    /** @internal */
-    abstract class SymfonyBridgeLoader extends ContainerAwareLoader
-    {
-    }
-} else {
-    /** @internal */
-    abstract class SymfonyBridgeLoader extends Loader
-    {
-    }
+/** @internal */
+abstract class SymfonyBridgeLoader extends Loader
+{
 }

--- a/src/Loader/SymfonyFixturesLoader.php
+++ b/src/Loader/SymfonyFixturesLoader.php
@@ -8,22 +8,20 @@ use Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesComp
 use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\DataFixtures\FixtureInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use LogicException;
 use ReflectionClass;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 use function array_keys;
 use function array_values;
+use function class_exists;
 use function get_class;
 use function sprintf;
-use function class_exists;
 
 final class SymfonyFixturesLoader extends SymfonyBridgeLoader
 {
-    /** @var bool */
     private bool $useContainerAwareLoader;
 
-    /** @var ?ContainerInterface */
     private ?ContainerInterface $container = null;
 
     /** @var FixtureInterface[] */
@@ -32,10 +30,10 @@ final class SymfonyFixturesLoader extends SymfonyBridgeLoader
     /** @var array<string, array<string, bool>> */
     private array $groupsFixtureMapping = [];
 
-    public function __construct(bool $useContainerAwareLoader, ContainerInterface $container = null)
+    public function __construct(bool $useContainerAwareLoader, ?ContainerInterface $container = null)
     {
         $this->useContainerAwareLoader = $useContainerAwareLoader;
-        $this->container = $container;
+        $this->container               = $container;
     }
 
     /**
@@ -60,9 +58,11 @@ final class SymfonyFixturesLoader extends SymfonyBridgeLoader
         }
     }
 
+    /** @psalm-suppress UndefinedClass */
     public function addFixture(FixtureInterface $fixture): void
     {
-        if ($this->useContainerAwareLoader && class_exists(ContainerAwareInterface::class) && $fixture instanceof ContainerAwareInterface) {
+        // phpcs:ignore
+        if ($this->useContainerAwareLoader && class_exists(\Symfony\Component\DependencyInjection\ContainerAwareInterface::class) && $fixture instanceof \Symfony\Component\DependencyInjection\ContainerAwareInterface) {
             $fixture->setContainer($this->container);
         }
 

--- a/tests/Command/LoadDataFixturesDoctrineCommandTest.php
+++ b/tests/Command/LoadDataFixturesDoctrineCommandTest.php
@@ -24,7 +24,8 @@ class LoadDataFixturesDoctrineCommandTest extends TestCase
     /** @group legacy */
     public function testInstantiatingWithoutManagerRegistry(): void
     {
-        $loader = new SymfonyFixturesLoader(new Container());
+        $container = new Container();
+        $loader = new SymfonyFixturesLoader(false, $container);
 
         $this->expectDeprecation('Since doctrine/fixtures-bundle 3.2: Argument 2 of Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand::__construct() expects an instance of Doctrine\Persistence\ManagerRegistry, not passing it will throw a \TypeError in DoctrineFixturesBundle 4.0.');
 
@@ -47,7 +48,8 @@ class LoadDataFixturesDoctrineCommandTest extends TestCase
     public function testInstantiatingWithManagerRegistry(): void
     {
         $registry = $this->createMock(ManagerRegistry::class);
-        $loader   = new SymfonyFixturesLoader(new Container());
+        $container = new Container();
+        $loader = new SymfonyFixturesLoader(false, $container);
 
         new LoadDataFixturesDoctrineCommand($loader, $registry);
     }

--- a/tests/Command/LoadDataFixturesDoctrineCommandTest.php
+++ b/tests/Command/LoadDataFixturesDoctrineCommandTest.php
@@ -25,7 +25,7 @@ class LoadDataFixturesDoctrineCommandTest extends TestCase
     public function testInstantiatingWithoutManagerRegistry(): void
     {
         $container = new Container();
-        $loader = new SymfonyFixturesLoader(false, $container);
+        $loader    = new SymfonyFixturesLoader(false, $container);
 
         $this->expectDeprecation('Since doctrine/fixtures-bundle 3.2: Argument 2 of Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand::__construct() expects an instance of Doctrine\Persistence\ManagerRegistry, not passing it will throw a \TypeError in DoctrineFixturesBundle 4.0.');
 
@@ -47,9 +47,9 @@ class LoadDataFixturesDoctrineCommandTest extends TestCase
     /** @doesNotPerformAssertions */
     public function testInstantiatingWithManagerRegistry(): void
     {
-        $registry = $this->createMock(ManagerRegistry::class);
+        $registry  = $this->createMock(ManagerRegistry::class);
         $container = new Container();
-        $loader = new SymfonyFixturesLoader(false, $container);
+        $loader    = new SymfonyFixturesLoader(false, $container);
 
         new LoadDataFixturesDoctrineCommand($loader, $registry);
     }


### PR DESCRIPTION
Fix deprecations and ensure compatibility with Symfony 6.4 (#420)

- Updated `SymfonyFixturesLoader` to conditionally set the container:
  - Added a `class_exists` check for `ContainerAwareInterface` in the `addFixture` method.
  - Passed `bool` and `ContainerInterface` to the constructor of `SymfonyFixturesLoader`.

- Updated `DoctrineFixturesExtension` for future compatibility:
  - Added `?ConfigurationInterface` return type to `getConfiguration` method.
  - Replaced `HttpKernelExtension` with `Symfony\Component\DependencyInjection\Extension\Extension`.

- Fixed tests to correctly initialize `SymfonyFixturesLoader`:
  - Updated `LoadDataFixturesDoctrineCommandTest` to pass correct parameters to `SymfonyFixturesLoader`.

- Implemented `isUninitializedObject` method in `EntityManagerDecorator` for future Doctrine compatibility.

These changes address deprecation warnings and ensure compatibility with Symfony 6.4 and future versions.
