### PR TITLE
Allow data-fixtures v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "doctrine/data-fixtures": "^1.3",
+        "doctrine/data-fixtures": "^1.5|^2.0",
         "doctrine/doctrine-bundle": "^2.2",
         "doctrine/orm": "^2.14.0 || ^3.0",
         "doctrine/persistence": "^2.4|^3.0",
@@ -29,7 +29,7 @@
         "symfony/console": "^5.4|^6.0|^7.0",
         "symfony/dependency-injection": "^5.4|^6.0|^7.0",
         "symfony/deprecation-contracts": "^2.1|^3",
-        "symfony/doctrine-bridge": "^5.4|^6.0|^7.0",
+        "symfony/doctrine-bridge": "^5.4.48|^6.4.16|^7.1.9",
         "symfony/http-kernel": "^5.4|^6.0|^7.0"
     },
     "require-dev": {

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -14,7 +14,7 @@ use Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures\OtherFi
 use Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures\RequiredConstructorArgsFixtures;
 use Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures\WithDeepDependenciesFixtures;
 use Doctrine\Bundle\FixturesBundle\Tests\Fixtures\FooBundle\DataFixtures\WithDependenciesFixtures;
-use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\Common\DataFixtures\Purger\ORMPurgerInterface;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
@@ -304,7 +304,7 @@ class IntegrationTest extends TestCase
         $container->set('doctrine', $registry);
 
         $purgerFactory = $this->createMock(PurgerFactory::class);
-        $purger        = $this->createMock(ORMPurger::class);
+        $purger        = $this->createMock(ORMPurgerInterface::class);
         $purgerFactory
             ->expects(self::once())
             ->method('createForEntityManager')
@@ -351,7 +351,7 @@ class IntegrationTest extends TestCase
         $container->set('doctrine', $registry);
 
         $purgerFactory = $this->createMock(PurgerFactory::class);
-        $purger        = $this->createMock(ORMPurger::class);
+        $purger        = $this->createMock(ORMPurgerInterface::class);
         $purgerFactory
             ->expects(self::once())
             ->method('createForEntityManager')
@@ -401,7 +401,7 @@ class IntegrationTest extends TestCase
         $container->set('doctrine', $registry);
 
         $purgerFactory = $this->createMock(PurgerFactory::class);
-        $purger        = $this->createMock(ORMPurger::class);
+        $purger        = $this->createMock(ORMPurgerInterface::class);
         $purgerFactory
             ->expects(self::once())
             ->method('createForEntityManager')
@@ -448,7 +448,7 @@ class IntegrationTest extends TestCase
         $container->set('doctrine', $registry);
 
         $purgerFactory = $this->createMock(PurgerFactory::class);
-        $purger        = $this->createMock(ORMPurger::class);
+        $purger        = $this->createMock(ORMPurgerInterface::class);
         $purgerFactory
             ->expects(self::once())
             ->method('createForEntityManager')


### PR DESCRIPTION
The interfaces introduced in 1.5.0 allow to test without mocking a final class.

Closes #456 