### PR TITLE
Update branch metadata

### DIFF
--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -5,7 +5,6 @@ branches:
     - "3.6.x"
     - "3.7.x"
 maintained_branches:
-    - "3.6.x"
     - "3.7.x"
 doc_dir: "docs/"
 dev_branch: "3.7.x"


### PR DESCRIPTION
- 3.6.x is no longer maintained.
- There is no 3.8.x because 4.0.x is going to be released soon.