### PR TITLE
Make PurgerFactory generic

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method class@anonymous/src/Command/LoadDataFixturesDoctrineCommand\\.php\\:121\\:\\:log\\(\\) has parameter \\$message with no type specified\\.$#"
+			message: "#^Method class@anonymous/src/Command/LoadDataFixturesDoctrineCommand\\.php\\:120\\:\\:log\\(\\) has parameter \\$message with no type specified\\.$#"
 			count: 1
 			path: src/Command/LoadDataFixturesDoctrineCommand.php
 

--- a/src/Command/LoadDataFixturesDoctrineCommand.php
+++ b/src/Command/LoadDataFixturesDoctrineCommand.php
@@ -10,7 +10,6 @@ use Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader;
 use Doctrine\Bundle\FixturesBundle\Purger\ORMPurgerFactory;
 use Doctrine\Bundle\FixturesBundle\Purger\PurgerFactory;
 use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
-use Doctrine\Common\DataFixtures\Purger\ORMPurgerInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\Log\AbstractLogger;
@@ -32,6 +31,7 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
     public function __construct(
         private SymfonyFixturesLoader $fixturesLoader,
         ManagerRegistry $doctrine,
+        /** @var array<string, ORMPurgerFactory> $purgerFactories */
         private array $purgerFactories = [],
     ) {
         parent::__construct($doctrine);
@@ -110,13 +110,12 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
             $factory = $this->purgerFactories[$input->getOption('purger')];
         }
 
-        $purger = $factory->createForEntityManager(
+        $purger   = $factory->createForEntityManager(
             $input->getOption('em'),
             $em,
             $input->getOption('purge-exclusions'),
             $input->getOption('purge-with-truncate'),
         );
-        assert($purger instanceof ORMPurgerInterface);
         $executor = new ORMExecutor($em, $purger);
         $executor->setLogger(new class ($ui) extends AbstractLogger {
             public function __construct(private SymfonyStyle $ui)

--- a/src/Purger/ORMPurgerFactory.php
+++ b/src/Purger/ORMPurgerFactory.php
@@ -7,6 +7,7 @@ namespace Doctrine\Bundle\FixturesBundle\Purger;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\ORM\EntityManagerInterface;
 
+/** @template-implements PurgerFactory<ORMPurger> */
 final class ORMPurgerFactory implements PurgerFactory
 {
     /**

--- a/src/Purger/PurgerFactory.php
+++ b/src/Purger/PurgerFactory.php
@@ -7,9 +7,14 @@ namespace Doctrine\Bundle\FixturesBundle\Purger;
 use Doctrine\Common\DataFixtures\Purger\PurgerInterface;
 use Doctrine\ORM\EntityManagerInterface;
 
+/** @template T of PurgerInterface */
 interface PurgerFactory
 {
-    /** @phpstan-param list<string> $excluded */
+    /**
+     * @phpstan-param list<string> $excluded
+     *
+     * @return T
+     */
     public function createForEntityManager(
         string|null $emName,
         EntityManagerInterface $em,

--- a/tests/Purger/ORMPurgerFactoryTest.php
+++ b/tests/Purger/ORMPurgerFactoryTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Purger;
+namespace Doctrine\Bundle\FixturesBundle\Tests\Purger;
 
 use Doctrine\Bundle\FixturesBundle\Purger\ORMPurgerFactory;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;

--- a/tests/Purger/ORMPurgerFactoryTest.php
+++ b/tests/Purger/ORMPurgerFactoryTest.php
@@ -10,8 +10,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-use function assert;
-
 class ORMPurgerFactoryTest extends TestCase
 {
     private ORMPurgerFactory $factory;
@@ -28,9 +26,7 @@ class ORMPurgerFactoryTest extends TestCase
     public function testCreateDefault(): void
     {
         $purger = $this->factory->createForEntityManager(null, $this->em);
-        assert($purger instanceof ORMPurger);
 
-        self::assertInstanceOf(ORMPurger::class, $purger);
         self::assertSame(ORMPurger::PURGE_MODE_DELETE, $purger->getPurgeMode());
         self::assertSame([], (function () {
             return $this->excluded;
@@ -40,9 +36,7 @@ class ORMPurgerFactoryTest extends TestCase
     public function testCreateWithExclusions(): void
     {
         $purger = $this->factory->createForEntityManager(null, $this->em, ['tableName']);
-        assert($purger instanceof ORMPurger);
 
-        self::assertInstanceOf(ORMPurger::class, $purger);
         self::assertSame(ORMPurger::PURGE_MODE_DELETE, $purger->getPurgeMode());
         self::assertSame(['tableName'], (function () {
             return $this->excluded;
@@ -52,9 +46,7 @@ class ORMPurgerFactoryTest extends TestCase
     public function testCreateWithTruncate(): void
     {
         $purger = $this->factory->createForEntityManager(null, $this->em, [], true);
-        assert($purger instanceof ORMPurger);
 
-        self::assertInstanceOf(ORMPurger::class, $purger);
         self::assertSame(ORMPurger::PURGE_MODE_TRUNCATE, $purger->getPurgeMode());
         self::assertSame([], (function () {
             return $this->excluded;


### PR DESCRIPTION
This allows us to remove assertions and natively provide the right type
information.

I'm targeting 4.0.x because I have no plans to release a new 3.x minor.