### PR TITLE
Add missing psr/log requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "doctrine/doctrine-bundle": "^2.2",
         "doctrine/orm": "^2.14.0 || ^3.0",
         "doctrine/persistence": "^2.4 || ^3.0",
+        "psr/log": "^1 || ^2 || ^3",
         "symfony/config": "^5.4 || ^6.0 || ^7.0",
         "symfony/console": "^5.4 || ^6.0 || ^7.0",
         "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",


### PR DESCRIPTION
I should have added it in ba7e5670b91e215ee47f8e173bf3964213707317 I have taken a look at the --prefer-lowest build, and it installs v1.1.0, so that's what we should use, at least for the next patch release.