### PR TITLE
Add 2nd parameter (class) to getReference() call

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -169,7 +169,7 @@ exact same object via its name.
         {
             $userGroup = new Group('administrators');
             // this reference returns the User object created in UserFixtures
-            $userGroup->addUser($this->getReference(UserFixtures::ADMIN_USER_REFERENCE));
+            $userGroup->addUser($this->getReference(UserFixtures::ADMIN_USER_REFERENCE, User::class));
 
             $manager->persist($userGroup);
             $manager->flush();


### PR DESCRIPTION
Since Doctrine data fixture v2, getReference() requires a second parameter, being the class.

This would address https://github.com/doctrine/data-fixtures/pull/464#issuecomment-2506003520

Hth,