### PR TITLE
Tag dependency injection classes as internal

### DIFF
--- a/src/DependencyInjection/CompilerPass/FixturesCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/FixturesCompilerPass.php
@@ -8,6 +8,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
+/** @internal */
 final class FixturesCompilerPass implements CompilerPassInterface
 {
     public const FIXTURE_TAG = 'doctrine.fixture.orm';

--- a/src/DependencyInjection/CompilerPass/PurgerFactoryCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/PurgerFactoryCompilerPass.php
@@ -11,6 +11,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 use function sprintf;
 
+/** @internal */
 final class PurgerFactoryCompilerPass implements CompilerPassInterface
 {
     public const PURGER_FACTORY_TAG = 'doctrine.fixtures.purger_factory';

--- a/src/DependencyInjection/DoctrineFixturesExtension.php
+++ b/src/DependencyInjection/DoctrineFixturesExtension.php
@@ -13,6 +13,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 use function dirname;
 
+/** @internal */
 final class DoctrineFixturesExtension extends Extension
 {
     /**


### PR DESCRIPTION
They are not meant to be used directly by project code.

This is prompted by https://github.com/doctrine/DoctrineFixturesBundle/pull/480#issuecomment-2516747861

> maybe more

```
src
├── Command
│   └── LoadDataFixturesDoctrineCommand.php
├── DependencyInjection
│   ├── CompilerPass
│   │   ├── FixturesCompilerPass.php
│   │   └── PurgerFactoryCompilerPass.php
│   └── DoctrineFixturesExtension.php
├── DoctrineFixturesBundle.php
├── FixtureGroupInterface.php
├── Fixture.php
├── Loader
│   └── SymfonyFixturesLoader.php
├── ORMFixtureInterface.php
└── Purger
    ├── ORMPurgerFactory.php
    └── PurgerFactory.php
```

Maybe the command and the bundle? Or maybe not… I'm not sure where to draw the line.  I will also mention that yesterday, I saw [this issue](https://github.com/doctrine/DoctrineBundle/issues/1844) raised by somebody who uses a compiler pass in their own code.

I'm targeting 4.0.x, because even if adding `@internal` is maybe not really a breaking change, once a class is tagged as internal, it would suddenly make it OK to make it `final`.