### PR TITLE
Fix compatibility for Symfony 6 projects without doctrine/persistence 3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "symfony/console": "^5.4 || ^6.0 || ^7.0",
         "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
         "symfony/deprecation-contracts": "^2.1 || ^3",
-        "symfony/doctrine-bridge": "^5.4.48 || ^6.4.16 || ^7.1.9",
+        "symfony/doctrine-bridge": "^5.4.48 || ~6.3.12 || ^6.4.16 || ^7.1.9",
         "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
This issue libraries run into which require / support still `doctrine/persistence: "^2"` on Symfony 6, see also https://github.com/doctrine/DoctrineBundle/pull/1841 which is the same problem. Symfony 6.4 does not support persistence 3 so 6.3 need still be added to support this correctly to avoid accidently downgrade of the doctrine/bridge which runs into following error.

Before:

> `Compile Error: Declaration of Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor::getProperties(string $class, array $context = []) must be compatible with Symfony\Component\PropertyInfo\PropertyListExtractorInterface::getProperties(string $class, array $context = []): ?arra`

![Bildschirmfoto 2024-12-11 um 12 24 59](https://github.com/user-attachments/assets/1fb51e64-72be-494d-8c23-9040094560f0)

After:

![Bildschirmfoto 2024-12-11 um 12 20 35](https://github.com/user-attachments/assets/75fabcfe-e296-4716-a823-c5b95faf2492)

Runs correctly.


