### PR TITLE
Tell Dependabot to target 3.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
       interval: "weekly"
     labels:
       - "CI"
+    target-branch: "3.7.x"


### PR DESCRIPTION
It is still maintained while we wait for the 4.x installs to increase.