### PR TITLE
Drop support for Symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,12 +29,12 @@
         "doctrine/orm": "^2.14.0 || ^3.0",
         "doctrine/persistence": "^2.4 || ^3.0",
         "psr/log": "^2 || ^3",
-        "symfony/config": "^5.4 || ^6.0 || ^7.0",
-        "symfony/console": "^5.4 || ^6.0 || ^7.0",
-        "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
+        "symfony/config": "^6.4 || ^7.0",
+        "symfony/console": "^6.4 || ^7.0",
+        "symfony/dependency-injection": "^6.4 || ^7.0",
         "symfony/deprecation-contracts": "^2.1 || ^3",
-        "symfony/doctrine-bridge": "^5.4.48 || ^6.4.16 || ^7.1.9",
-        "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0"
+        "symfony/doctrine-bridge": "^6.4.16 || ^7.1.9",
+        "symfony/http-kernel": "^6.4 || ^7.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^12",


### PR DESCRIPTION
Symfony's 5.x branch is not actively maintained anymore. Time to move on!

Draft: We don't have a 4.1.x branch yet.