### PR TITLE
Pin development tools

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,10 +37,10 @@
         "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {
-        "doctrine/coding-standard": "^12",
-        "phpstan/phpstan": "^2",
-        "phpunit/phpunit": "^9.6.13",
-        "symfony/phpunit-bridge": "^6.3.6"
+        "doctrine/coding-standard": "12.0.0",
+        "phpstan/phpstan": "2.1.8",
+        "phpunit/phpunit": "^9.6.13 || 11.4.14",
+        "symfony/phpunit-bridge": "6.4.16"
     },
     "conflict": {
         "doctrine/dbal": "< 3"


### PR DESCRIPTION
We have jobs in our CI that run with unstable deps, but we are not really interested in getting unstable deps for our development tools.