### PR TITLE
chore: update branch metadata

### DIFF
--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -5,8 +5,9 @@ branches:
     - "3.6.x"
     - "3.7.x"
     - "4.0.x"
+    - "4.1.x"
 maintained_branches:
     - "3.7.x"
-    - "4.0.x"
+    - "4.1.x"
 doc_dir: "docs/"
-dev_branch: "4.0.x"
+dev_branch: "4.1.x"


### PR DESCRIPTION
- 4.0.x is no longer maintained
- 4.1.x is new, and is the dev branch