### PR TITLE
Alexdawn/feature/list option

### DIFF
--- a/src/Command/LoadDataFixturesDoctrineCommand.php
+++ b/src/Command/LoadDataFixturesDoctrineCommand.php
@@ -51,6 +51,7 @@ final class LoadDataFixturesDoctrineCommand extends DoctrineCommand
             ->addOption('purge-exclusions', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'List of database tables to ignore while purging')
             ->addOption('purge-with-truncate', null, InputOption::VALUE_NONE, 'Purge data by using a database-level TRUNCATE statement')
             ->addOption('list', 'l', InputOption::VALUE_NONE, 'list fixtures in a table without running them, respects the --group filter')
+            ->addOption('filter-name', 'f', InputOption::VALUE_REQUIRED, 'provide all or part of a fully-qualified class name of a fixture to filter to')
             ->setHelp(<<<'EOT'
                 The <info>%command.name%</info> command loads data fixtures from your application:
 
@@ -87,8 +88,9 @@ final class LoadDataFixturesDoctrineCommand extends DoctrineCommand
             }
         }
 
-        $groups   = $input->getOption('group');
-        $fixtures = $this->fixturesLoader->getFixtures($groups);
+        $groups = $input->getOption('group');
+        $filterName = $input->hasOption('filter-name') ? $input->getOption('filter-name') : null;
+        $fixtures = $this->fixturesLoader->getFixtures($groups, $filterName);
 
         if ($input->getOption('list')) {
             $ui->table(

--- a/src/Command/LoadDataFixturesDoctrineCommand.php
+++ b/src/Command/LoadDataFixturesDoctrineCommand.php
@@ -7,6 +7,7 @@ namespace Doctrine\Bundle\FixturesBundle\Command;
 use Doctrine\Bundle\DoctrineBundle\Command\DoctrineCommand;
 use Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\PurgerFactoryCompilerPass;
 use Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader;
+use Doctrine\Bundle\FixturesBundle\ORMFixtureInterface;
 use Doctrine\Bundle\FixturesBundle\Purger\ORMPurgerFactory;
 use Doctrine\Bundle\FixturesBundle\Purger\PurgerFactory;
 use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
@@ -49,26 +50,27 @@ final class LoadDataFixturesDoctrineCommand extends DoctrineCommand
             ->addOption('purger', null, InputOption::VALUE_REQUIRED, 'The purger to use for this command', 'default')
             ->addOption('purge-exclusions', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'List of database tables to ignore while purging')
             ->addOption('purge-with-truncate', null, InputOption::VALUE_NONE, 'Purge data by using a database-level TRUNCATE statement')
+            ->addOption('list', 'l', InputOption::VALUE_NONE, 'list fixtures in a table without running them, respects the --group filter')
             ->setHelp(<<<'EOT'
                 The <info>%command.name%</info> command loads data fixtures from your application:
-                
+
                   <info>php %command.full_name%</info>
-                
+
                 Fixtures are services that are tagged with <comment>doctrine.fixture.orm</comment>.
-                
+
                 If you want to append the fixtures instead of flushing the database first you can use the <comment>--append</comment> option:
-                
+
                   <info>php %command.full_name%</info> <comment>--append</comment>
-                
+
                 By default Doctrine Data Fixtures uses DELETE statements to drop the existing rows from the database.
                 If you want to use a TRUNCATE statement instead you can use the <comment>--purge-with-truncate</comment> flag:
-                
+
                   <info>php %command.full_name%</info> <comment>--purge-with-truncate</comment>
-                
+
                 To execute only fixtures that live in a certain group, use:
-                
+
                   <info>php %command.full_name%</info> <comment>--group=group1</comment>
-                
+
                 EOT);
     }
 
@@ -79,7 +81,7 @@ final class LoadDataFixturesDoctrineCommand extends DoctrineCommand
         $em = $this->getDoctrine()->getManager($input->getOption('em'));
         assert($em instanceof EntityManagerInterface);
 
-        if (! $input->getOption('append')) {
+        if (! $input->getOption('list') && ! $input->getOption('append')) {
             if (! $ui->confirm(sprintf('Careful, database "%s" will be purged. Do you want to continue?', $em->getConnection()->getDatabase()), ! $input->isInteractive())) {
                 return 0;
             }
@@ -87,6 +89,23 @@ final class LoadDataFixturesDoctrineCommand extends DoctrineCommand
 
         $groups   = $input->getOption('group');
         $fixtures = $this->fixturesLoader->getFixtures($groups);
+
+        if ($input->getOption('list')) {
+            $ui->table(
+                ['name', 'group', 'dependencies'],
+                array_map(
+                    /** @param ORMFixtureInterface|FixtureGroupInterface|DependentFixtureInterface $fixture */
+                    fn(ORMFixtureInterface $fixture) => [
+                        $fixture::class,
+                        implode(',', method_exists($fixture, 'getGroups') ? $fixture->getGroups() : []),
+                        implode(',', method_exists($fixture, 'getDependencies') ? $fixture->getDependencies() : [])
+                    ],
+                    $fixtures
+                )
+            );
+            return 0;
+        }
+
         if (! $fixtures) {
             $message = 'Could not find any fixture services to load';
 

--- a/src/Loader/SymfonyFixturesLoader.php
+++ b/src/Loader/SymfonyFixturesLoader.php
@@ -91,11 +91,11 @@ final class SymfonyFixturesLoader extends Loader
      *
      * @return FixtureInterface[]
      */
-    public function getFixtures(array $groups = []): array
+    public function getFixtures(array $groups = [], ?string $filterName = null): array
     {
         $fixtures = parent::getFixtures();
 
-        if (empty($groups)) {
+        if (empty($groups) && is_null($filterName)) {
             return $fixtures;
         }
 
@@ -111,7 +111,10 @@ final class SymfonyFixturesLoader extends Loader
         $filteredFixtures = [];
         foreach ($fixtures as $order => $fixture) {
             $fixtureClass = $fixture::class;
-            if (isset($requiredFixtures[$fixtureClass])) {
+            if (
+                isset($requiredFixtures[$fixtureClass])
+                && (is_null($filterName) || str_contains($fixtureClass, $filterName))
+            ) {
                 $filteredFixtures[$order] = $fixture;
                 continue;
             }


### PR DESCRIPTION
Sorry If i've missed anything this is my first contribution to  a symfony project. I've tried to follow PSR and symfony style guides.

A couple of optional flags, I've needed to help run fixtures on a private project, that should be useful to anyone else trying to see a list of fixtures or debug single fixtures in a project with many many fixtures or multiple entity-managers.

--list shows all the fixtures and any dependencies, groups in a symfony table (respects both group and filter-name filters)
--filter-name allows filtering of fixtures by name in addition to group

closes my feature request #508