### PR TITLE
feat: add --dry-run option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "homepage": "https://www.doctrine-project.org",
     "require": {
         "php": "^8.1",
-        "doctrine/data-fixtures": "^2.0",
+        "doctrine/data-fixtures": "^2.2",
         "doctrine/doctrine-bundle": "^2.2 || ^3.0",
         "doctrine/orm": "^2.14.0 || ^3.0",
         "doctrine/persistence": "^2.4 || ^3.0 || ^4.0",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -383,6 +383,30 @@ With the ``--purger`` option we can now specify to use ``my_purger`` instead of 
 .. _`Doctrine ORM`: https://symfony.com/doc/current/doctrine.html
 .. _`DoctrineMongoDBBundle`: https://github.com/doctrine/DoctrineMongoDBBundle
 
+Loading Fixtures in Dry Run mode
+--------------------------------
+
+The ``--dry-run`` option allows you to simulate the execution of your fixtures 
+and see what would happen if they were executed, without actually applying 
+any changes to the database.
+
+This way, you can inspect the behavior of your fixtures safely, without modifying your database.
+
+.. code-block:: terminal
+
+    $ php bin/console doctrine:fixtures:load --dry-run
+
+You can also combine ``--dry-run`` with other options such as ``--append`` or ``--group``:
+
+.. code-block:: terminal
+
+    $ php bin/console doctrine:fixtures:load --group=group1 --append --dry-run
+
+.. note::
+
+    When using ``--dry-run`` option, all persisting operations are skipped.  
+    The fixtures will be processed, and any logging or output will behave as usual,
+    but no database changes will occur.
 
 How to load Fixtures from a different Directory
 -----------------------------------------------

--- a/src/Command/LoadDataFixturesDoctrineCommand.php
+++ b/src/Command/LoadDataFixturesDoctrineCommand.php
@@ -9,6 +9,7 @@ use Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\PurgerFactor
 use Doctrine\Bundle\FixturesBundle\Loader\FixturesProvider;
 use Doctrine\Bundle\FixturesBundle\Purger\ORMPurgerFactory;
 use Doctrine\Bundle\FixturesBundle\Purger\PurgerFactory;
+use Doctrine\Common\DataFixtures\Executor\DryRunORMExecutor;
 use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
@@ -44,6 +45,7 @@ final class LoadDataFixturesDoctrineCommand extends DoctrineCommand
             ->setName('doctrine:fixtures:load')
             ->setDescription('Load data fixtures to your database')
             ->addOption('append', null, InputOption::VALUE_NONE, 'Append the data fixtures instead of deleting all data from the database first.')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Load the fixtures as a dry run.')
             ->addOption('group', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Only load fixtures that belong to this group')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
             ->addOption('purger', null, InputOption::VALUE_REQUIRED, 'The purger to use for this command', 'default')
@@ -68,6 +70,10 @@ final class LoadDataFixturesDoctrineCommand extends DoctrineCommand
                 To execute only fixtures that live in a certain group, use:
                 
                   <info>php %command.full_name%</info> <comment>--group=group1</comment>
+
+                You can also load the fixtures as a <comment>--dry-run</comment>:
+
+                  <info>php %command.full_name% --dry-run</info>
                 
                 EOT);
     }
@@ -79,7 +85,7 @@ final class LoadDataFixturesDoctrineCommand extends DoctrineCommand
         $em = $this->getDoctrine()->getManager($input->getOption('em'));
         assert($em instanceof EntityManagerInterface);
 
-        if (! $input->getOption('append')) {
+        if (! $input->getOption('dry-run') && ! $input->getOption('append')) {
             if (! $ui->confirm(sprintf('Careful, database "%s" will be purged. Do you want to continue?', $em->getConnection()->getDatabase()), ! $input->isInteractive())) {
                 return 0;
             }
@@ -111,13 +117,20 @@ final class LoadDataFixturesDoctrineCommand extends DoctrineCommand
             $factory = $this->purgerFactories[$input->getOption('purger')];
         }
 
-        $purger   = $factory->createForEntityManager(
+        $purger = $factory->createForEntityManager(
             $input->getOption('em'),
             $em,
             $input->getOption('purge-exclusions'),
             $input->getOption('purge-with-truncate'),
         );
-        $executor = new ORMExecutor($em, $purger);
+
+        if ($input->getOption('dry-run')) {
+            $ui->text('  <comment>(dry-run)</comment>');
+            $executor = new DryRunORMExecutor($em, $purger);
+        } else {
+            $executor = new ORMExecutor($em, $purger);
+        }
+
         $executor->setLogger(new class ($ui) extends AbstractLogger {
             public function __construct(private SymfonyStyle $ui)
             {

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -459,6 +459,54 @@ class IntegrationTest extends TestCase
         $tester = new CommandTester($command);
         $tester->execute(['--purge-with-truncate' => true], ['interactive' => false]);
     }
+
+    public function testRunCommandWithDryRunOption(): void
+    {
+        $kernel = new IntegrationTestKernel('dev', true);
+        $kernel->addServices(static function (ContainerBuilder $c): void {
+            // has a "staging" group via the getGroups() method
+            $c->autowire(OtherFixtures::class)
+                ->addTag(FixturesCompilerPass::FIXTURE_TAG);
+
+            // no getGroups() method
+            $c->autowire(WithDependenciesFixtures::class)
+                ->addTag(FixturesCompilerPass::FIXTURE_TAG);
+
+            $c->getDefinition('doctrine')
+                ->setPublic(true)
+                ->setSynthetic(true);
+
+            $c->setAlias('test.doctrine.fixtures.purger.orm_purger_factory', new Alias('doctrine.fixtures.purger.orm_purger_factory', true));
+
+            $c->setAlias('test.doctrine.fixtures_load_command', new Alias('doctrine.fixtures_load_command', true));
+        });
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        $em       = $this->createConfiguredMock(ForwardCompatibleEntityManager::class, ['getConnection' => $this->createMock(Connection::class), 'getEventManager' => $this->createMock(EventManager::class)]);
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry
+            ->expects(self::once())
+            ->method('getManager')
+            ->with(null)
+            ->willReturn($em);
+        $container->set('doctrine', $registry);
+
+        $purgerFactory = $this->createMock(PurgerFactory::class);
+        $purger        = $this->createMock(ORMPurgerInterface::class);
+        $purgerFactory
+            ->expects(self::once())
+            ->method('createForEntityManager')
+            ->with(null, $em, [])
+            ->willReturn($purger);
+        $container->set('test.doctrine.fixtures.purger.orm_purger_factory', $purgerFactory);
+
+        $command = $container->get('test.doctrine.fixtures_load_command');
+        $this->assertInstanceOf(LoadDataFixturesDoctrineCommand::class, $command);
+        $tester = new CommandTester($command);
+        $tester->execute(['--dry-run' => true], ['interactive' => false]);
+        $this->assertStringContainsString('(dry-run)', $tester->getDisplay());
+    }
 }
 
 interface ForwardCompatibleEntityManager extends EntityManagerInterface


### PR DESCRIPTION
Add `--dry-run` option to `doctrine:fixtures:load` command to display loaded fixtures without actually loading them

```bash
php bin/console doctrine:fixtures:load --dry-run
```

closes: #511 #508 