### PR TITLE
Fix custom Purger code sample

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -299,11 +299,19 @@ You can also customize purging behavior significantly more and implement a custo
     // src/Purger/CustomPurger.php
     namespace App\Purger;
 
-    use Doctrine\Common\DataFixtures\Purger\PurgerInterface;
+    use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+    use Doctrine\Common\DataFixtures\Purger\ORMPurgerInterface;
+    use Doctrine\ORM\EntityManagerInterface;
 
-    // ...
-    class CustomPurger implements PurgerInterface
+    class CustomPurger implements ORMPurgerInterface
     {
+        private EntityManagerInterface $entityManager;
+
+        public function setEntityManager(EntityManagerInterface $em): void
+        {
+            $this->entityManager = $em;
+        }
+
         public function purge(): void
         {
             // ...
@@ -319,7 +327,7 @@ You can also customize purging behavior significantly more and implement a custo
     {
         public function createForEntityManager(?string $emName, EntityManagerInterface $em, array $excluded = [], bool $purgeWithTruncate = false) : PurgerInterface
         {
-            return new CustomPurger($em);
+            return new CustomPurger();
         }
     }
 


### PR DESCRIPTION
Page: https://symfony.com/bundles/DoctrineFixturesBundle/current/index.html#specifying-purging-behavior

Wasn't working for me, I was getting:
> In ORMExecutorCommon.php line 23:
Doctrine\Common\DataFixtures\Executor\ORMExecutor::__construct(): Argument #2 ($purger) must be of type ?Doctrine\Common\DataFixtures\Purger\ORMPurgerInterface, App\DataFixtures\CustomPurger given,

Question: What is the factory needed for?