### PR TITLE
Update the Symfony bundle configuration

### DIFF
--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -10,4 +10,5 @@ maintained_branches:
     - "3.7.x"
     - "4.1.x"
 doc_dir: "docs/"
+current_branch: "4.1.x"
 dev_branch: "4.1.x"

--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -9,6 +9,8 @@ branches:
 maintained_branches:
     - "3.7.x"
     - "4.1.x"
+    - "4.2.x"
+    - "4.3.x"
 doc_dir: "docs/"
-current_branch: "4.1.x"
-dev_branch: "4.1.x"
+current_branch: "4.2.x"
+dev_branch: "4.3.x"


### PR DESCRIPTION
We're having some issues with the docs of this bundle on symfony.com. The `current_branch` config option is missing, so lets add it. Thanks!

Note: we only check the `.symfony.bundle.yaml` of the default branch in the GitHub repository, so all the other files are ignored.