### PR TITLE
Update bundle config

### DIFF
--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -7,6 +7,8 @@ branches:
     - "4.0.x"
     - "4.1.x"
     - "4.2.x"
+    - "4.3.x"
+    - "4.4.x"
 maintained_branches:
     - "3.7.x"
     - "4.3.x"


### PR DESCRIPTION
On https://symfony.com/bundles/DoctrineFixturesBundle/current/index.html the branches 4.3.x and 4.4.x are not shown. This is because they are not listed under `branches`, only under `maintained_branches`.

The `branches` key should list all the brnaches that are still relevant to show the docs. For example, if a branch is legacy but still has a lot of users, it's fine to keep it in `branches`. But, if two or more branches are very similar and their docs are compatible (e.g. `3.5.x`, `3.6.x` and `3.7.x`), you can remove all repeated branches and keep only the most relevant one (e.g. `3.7.x`).