### PR TITLE
Flag 3.7.x as unmaintained

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,11 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "Dependencies"
-    target-branch: "3.7.x"
+    target-branch: "4.3.x"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     labels:
       - "CI"
-    target-branch: "3.7.x"
+    target-branch: "4.3.x"

--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -10,7 +10,6 @@ branches:
     - "4.3.x"
     - "4.4.x"
 maintained_branches:
-    - "3.7.x"
     - "4.3.x"
     - "4.4.x"
 doc_dir: "docs/"


### PR DESCRIPTION
We've released 4.0.0 a year ago and I believe the migration path from 3.7 is easy enough. Let's stop maintaining two major branches of this bundle in order to keep things simple for us.