### PR TITLE
Group Doctrine workflow updates together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,7 @@ updates:
     labels:
       - "CI"
     target-branch: "4.3.x"
+    groups:
+      doctrine:
+        patterns:
+          - "doctrine/*"


### PR DESCRIPTION
We do very small releases, often touching only one workflow, which means it is unlikely to have several issues when attempting to bump several references to this repository.